### PR TITLE
Ensure user projection catches up before read models are queried

### DIFF
--- a/osouji-touban-service/osouji-system-frontend/package-lock.json
+++ b/osouji-touban-service/osouji-system-frontend/package-lock.json
@@ -134,6 +134,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -493,6 +494,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -533,6 +535,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1967,6 +1970,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.166.3.tgz",
       "integrity": "sha512-5NOwAnEp+koHYaRkK5+biYiuOxnQe/7q8R7LLAJ5Ryk6hXoIimOv6gWimPxANwhCWg9spfRZCNswi8EQaidYBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.161.4",
         "@tanstack/react-store": "^0.9.1",
@@ -2277,8 +2281,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2349,6 +2352,7 @@
       "version": "24.12.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2357,6 +2361,7 @@
       "version": "19.2.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2365,6 +2370,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2415,6 +2421,7 @@
       "version": "8.56.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2804,6 +2811,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3054,6 +3062,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3397,8 +3406,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
@@ -3511,6 +3519,7 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4145,6 +4154,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4524,7 +4534,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4620,6 +4629,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -4941,7 +4951,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4957,7 +4966,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4976,6 +4984,7 @@
     "node_modules/react": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4983,6 +4992,7 @@
     "node_modules/react-dom": {
       "version": "19.2.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4995,8 +5005,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -5183,6 +5192,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
       "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -5571,6 +5581,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5682,6 +5693,7 @@
       "version": "8.0.0-beta.16",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.31.1",
@@ -5761,6 +5773,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -6051,6 +6064,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/osouji-touban-service/src/OsoujiSystem.Infrastructure/Projection/MainProjectionWorker.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Infrastructure/Projection/MainProjectionWorker.cs
@@ -109,6 +109,10 @@ internal sealed class MainProjector(
                 await ProjectWeeklyPlanAsync(connection, transaction, ev.StreamId);
                 changedWeeklyPlanIds.Add(ev.StreamId);
             }
+            else if (string.Equals(ev.StreamType, EventStoreDocuments.ManagedUserStreamType, StringComparison.Ordinal))
+            {
+                await ProjectManagedUserAsync(connection, transaction, ev.StreamId);
+            }
         }
 
         var lastPosition = events[^1].GlobalPosition;
@@ -717,8 +721,100 @@ internal sealed class MainProjector(
         }
     }
 
+    private async Task ProjectManagedUserAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        Guid streamId)
+    {
+        var snapshot = await connection.QuerySingleOrDefaultAsync<SnapshotRow>(
+            """
+            SELECT last_included_version AS Version,
+                   snapshot_payload::text AS Payload
+            FROM event_store_snapshots
+            WHERE stream_id = @streamId
+              AND stream_type = @streamType;
+            """,
+            new { streamId, streamType = EventStoreDocuments.ManagedUserStreamType },
+            transaction: transaction);
+
+        if (snapshot is null)
+        {
+            return;
+        }
+
+        var sourceEvent = await connection.QuerySingleOrDefaultAsync<LatestEventRow>(
+            """
+            SELECT event_id AS EventId,
+                   stream_version AS StreamVersion
+            FROM event_store_events
+            WHERE stream_id = @streamId
+              AND stream_type = @streamType
+            ORDER BY stream_version DESC
+            LIMIT 1;
+            """,
+            new { streamId, streamType = EventStoreDocuments.ManagedUserStreamType },
+            transaction: transaction);
+
+        if (sourceEvent is null || sourceEvent.StreamVersion != snapshot.Version)
+        {
+            return;
+        }
+
+        var user = eventStoreDocuments.DeserializeManagedUserSnapshot(streamId, snapshot.Payload);
+
+        await connection.ExecuteAsync(
+            """
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                email_address,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                updated_at
+            )
+            VALUES (
+                @userId,
+                @employeeNumber,
+                @displayName,
+                @emailAddress,
+                @lifecycleStatus,
+                @departmentCode,
+                @sourceEventId,
+                @aggregateVersion,
+                now()
+            )
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                employee_number = EXCLUDED.employee_number,
+                display_name = EXCLUDED.display_name,
+                email_address = EXCLUDED.email_address,
+                lifecycle_status = EXCLUDED.lifecycle_status,
+                department_code = EXCLUDED.department_code,
+                source_event_id = EXCLUDED.source_event_id,
+                aggregate_version = EXCLUDED.aggregate_version,
+                updated_at = now()
+            WHERE projection_user_directory.aggregate_version <= EXCLUDED.aggregate_version;
+            """,
+            new
+            {
+                userId = user.Id.Value,
+                employeeNumber = user.EmployeeNumber.Value,
+                displayName = user.DisplayName.Value,
+                emailAddress = user.EmailAddress?.Value,
+                lifecycleStatus = user.LifecycleStatus.ToString(),
+                departmentCode = user.DepartmentCode,
+                sourceEventId = sourceEvent.EventId,
+                aggregateVersion = snapshot.Version
+            },
+            transaction: transaction);
+    }
+
     private sealed record EventEnvelope(long GlobalPosition, Guid StreamId, string StreamType);
     private sealed record SnapshotRow(long Version, string Payload);
+    private sealed record LatestEventRow(Guid EventId, long StreamVersion);
     private sealed record ReadModelCacheInvalidationOperation(
         string CacheKey,
         ReadModelCacheInvalidationOperationKind OperationKind,

--- a/osouji-touban-service/src/OsoujiSystem.Infrastructure/Queries/Postgres/PostgresUserReadRepository.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Infrastructure/Queries/Postgres/PostgresUserReadRepository.cs
@@ -18,16 +18,15 @@ internal sealed class PostgresUserReadRepository(
         var row = await connection.QuerySingleOrDefaultAsync<DetailRow>(
             """
             SELECT
-                s.stream_id AS Id,
-                s.snapshot_payload ->> 'employeeNumber' AS EmployeeNumber,
-                COALESCE(s.snapshot_payload ->> 'displayName', '') AS DisplayName,
-                s.snapshot_payload ->> 'emailAddress' AS EmailAddress,
-                s.snapshot_payload ->> 'lifecycleStatus' AS LifecycleStatus,
-                s.snapshot_payload ->> 'departmentCode' AS DepartmentCode,
-                s.last_included_version AS Version
-            FROM event_store_snapshots s
-            WHERE s.stream_type = 'managed_user'
-              AND s.stream_id = @userId;
+                u.user_id AS Id,
+                u.employee_number AS EmployeeNumber,
+                u.display_name AS DisplayName,
+                u.email_address AS EmailAddress,
+                u.lifecycle_status AS LifecycleStatus,
+                u.department_code AS DepartmentCode,
+                u.aggregate_version AS Version
+            FROM projection_user_directory u
+            WHERE u.user_id = @userId;
             """,
             new { userId });
 

--- a/osouji-touban-service/tests/OsoujiSystem.WebApi.Tests/UserManagementApiTests.cs
+++ b/osouji-touban-service/tests/OsoujiSystem.WebApi.Tests/UserManagementApiTests.cs
@@ -46,6 +46,51 @@ public sealed class UserManagementApiTests(ApiIntegrationTestFixture fixture) : 
     }
 
     [Fact]
+    public async Task RegisterUser_AfterProjectionDrain_ShouldBeVisibleInUserReadModelAndAreaAssignment()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/users", new
+        {
+            employeeNumber = "123456",
+            displayName = "Hanako",
+            emailAddress = "hanako@example.com",
+            departmentCode = "OPS",
+            registrationSource = "adminPortal"
+        }, TestContext.Current.CancellationToken);
+
+        var createBody = await response.Content.ReadFromJsonAsync<JsonObject>(TestContext.Current.CancellationToken);
+        var userId = Guid.Parse(createBody!["data"]!["userId"]!.GetValue<string>());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await fixture.DrainProjectionAsync(TestContext.Current.CancellationToken);
+
+        var detailResponse = await _client.GetAsync($"/api/v1/users/{userId:D}", TestContext.Current.CancellationToken);
+        var detailBody = await detailResponse.Content.ReadFromJsonAsync<JsonObject>(TestContext.Current.CancellationToken);
+        detailResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        detailBody!["data"]!["displayName"]!.GetValue<string>().Should().Be("Hanako");
+        detailBody["data"]!["emailAddress"]!.GetValue<string>().Should().Be("hanako@example.com");
+
+        var listResponse = await _client.GetAsync("/api/v1/users?query=123456&sort=employeeNumber", TestContext.Current.CancellationToken);
+        var listBody = await listResponse.Content.ReadFromJsonAsync<JsonObject>(TestContext.Current.CancellationToken);
+        listResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        listBody!["data"]!.AsArray().Should().Contain(node => node!["userId"]!.GetValue<string>() == userId.ToString("D"));
+
+        var areaId = Guid.NewGuid();
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+
+        using var assignRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/v1/cleaning-areas/{areaId}/members");
+        assignRequest.Headers.IfMatch.Add(new EntityTagHeaderValue(etag));
+        assignRequest.Content = JsonContent.Create(new
+        {
+            userId
+        });
+
+        var assignResponse = await _client.SendAsync(assignRequest, TestContext.Current.CancellationToken);
+        assignResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+    }
+
+    [Fact]
     public async Task UpdateUserProfile_WithIfMatch_ShouldAdvanceVersion()
     {
         var createResponse = await _client.PostAsJsonAsync("/api/v1/users", new
@@ -90,6 +135,8 @@ public sealed class UserManagementApiTests(ApiIntegrationTestFixture fixture) : 
 
         var createBody = await createResponse.Content.ReadFromJsonAsync<JsonObject>(TestContext.Current.CancellationToken);
         var userId = Guid.Parse(createBody!["data"]!["userId"]!.GetValue<string>());
+
+        await fixture.DrainProjectionAsync(TestContext.Current.CancellationToken);
 
         var response = await _client.GetAsync($"/api/v1/users/{userId:D}", TestContext.Current.CancellationToken);
         var body = await response.Content.ReadFromJsonAsync<JsonObject>(TestContext.Current.CancellationToken);
@@ -184,9 +231,16 @@ public sealed class UserManagementApiTests(ApiIntegrationTestFixture fixture) : 
     public async Task AssignUserToArea_WithoutEmployeeNumber_ShouldUseUserDirectoryProjection()
     {
         var areaId = Guid.NewGuid();
-        var userId = new UserId(Guid.NewGuid());
         await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
-        await SeedUserDirectoryAsync(userId, "123456", "Hanako", ManagedUserLifecycleStatus.Active);
+
+        var registerResponse = await _client.PostAsJsonAsync("/api/v1/users", new
+        {
+            employeeNumber = "123456",
+            displayName = "Hanako",
+            registrationSource = "adminPortal"
+        }, TestContext.Current.CancellationToken);
+        var registerBody = await registerResponse.Content.ReadFromJsonAsync<JsonObject>(TestContext.Current.CancellationToken);
+        var userId = new UserId(Guid.Parse(registerBody!["data"]!["userId"]!.GetValue<string>()));
 
         var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
 


### PR DESCRIPTION
Summary
- have the main projector refresh the managed user read model when a user snapshot is present so queries rely on the latest data
- switch the user read repository to the projection table instead of reading directly from snapshots
- expand Web API integration tests to cover the post-registration flow guard and projection-driven assignment path

Testing
- Not run (not requested)