### PR TITLE
Fix navigation to clear weekId when selecting plan details

### DIFF
--- a/osouji-touban-service/osouji-system-frontend/src/routes/_app/-weekly-duty-plans.test.tsx
+++ b/osouji-touban-service/osouji-system-frontend/src/routes/_app/-weekly-duty-plans.test.tsx
@@ -9,6 +9,7 @@ import { server } from '../../test/server'
 
 const areaId = '11111111-1111-4111-8111-111111111111'
 const planId = '22222222-2222-4222-8222-222222222222'
+const secondPlanId = '55555555-5555-4555-8555-555555555555'
 
 function renderRoute(path = '/weekly-duty-plans') {
   const queryClient = new QueryClient({
@@ -187,5 +188,85 @@ describe('weekly duty plans page', () => {
 
     expect(generateCalls).toBe(0)
     expect(screen.getByText('Too small: expected number to be >=1')).toBeVisible()
+  })
+
+  it('keeps the area history list when opening plan details', async () => {
+    mockWeeklyDutyPlanApis()
+    server.use(
+      http.get('/api/v1/weekly-duty-plans', ({ request }) => {
+        const url = new URL(request.url)
+        const weekId = url.searchParams.get('weekId')
+
+        const plans = [
+          {
+            id: planId,
+            areaId,
+            weekId: '2026-W10',
+            weekLabel: '2026/3/2 週',
+            revision: 1,
+            status: 'draft' as const,
+            version: 1,
+          },
+          {
+            id: secondPlanId,
+            areaId,
+            weekId: '2026-W09',
+            weekLabel: '2026/2/23 週',
+            revision: 1,
+            status: 'published' as const,
+            version: 1,
+          },
+        ]
+
+        return HttpResponse.json({
+          data: weekId ? plans.filter((plan) => plan.weekId === weekId) : plans,
+          meta: {
+            limit: 20,
+            hasNext: false,
+            nextCursor: null,
+          },
+          links: {
+            self: '/api/v1/weekly-duty-plans',
+          },
+        })
+      }),
+      http.get('/api/v1/weekly-duty-plans/:selectedPlanId', ({ params }) => HttpResponse.json({
+        data: {
+          id: params.selectedPlanId,
+          areaId,
+          weekId: params.selectedPlanId === secondPlanId ? '2026-W09' : '2026-W10',
+          weekLabel: params.selectedPlanId === secondPlanId ? '2026/2/23 週' : '2026/3/2 週',
+          revision: 1,
+          status: params.selectedPlanId === secondPlanId ? 'published' : 'draft',
+          version: 1,
+          assignmentPolicy: { fairnessWindowWeeks: 4 },
+          assignments: [
+            {
+              spotId: '33333333-3333-4333-8333-333333333333',
+              userId: '44444444-4444-4444-8444-444444444444',
+              user: {
+                userId: '44444444-4444-4444-8444-444444444444',
+                employeeNumber: '123456',
+                displayName: 'Hanako',
+                departmentCode: 'OPS',
+                lifecycleStatus: 'active',
+              },
+            },
+          ],
+          offDutyEntries: [],
+        },
+      }, { headers: { ETag: '"1"' } })),
+    )
+
+    const { user } = renderRoute(`/weekly-duty-plans?areaId=${areaId}`)
+
+    expect(await screen.findByText('2026/3/2 週')).toBeVisible()
+    expect(await screen.findByText('2026/2/23 週')).toBeVisible()
+
+    const detailButtons = await screen.findAllByRole('button', { name: '詳細' })
+    await user.click(detailButtons[1]!)
+
+    expect(await screen.findByText('2026/3/2 週')).toBeVisible()
+    expect(await screen.findByText('2026/2/23 週')).toBeVisible()
   })
 })

--- a/osouji-touban-service/osouji-system-frontend/src/routes/_app/weekly-duty-plans.tsx
+++ b/osouji-touban-service/osouji-system-frontend/src/routes/_app/weekly-duty-plans.tsx
@@ -206,7 +206,7 @@ function WeeklyDutyPlansPage() {
                     </td>
                     <td className="px-4 py-4 text-sm text-slate-600">r{item.revision}</td>
                     <td className="px-4 py-4">
-                      <Button tone="secondary" onClick={() => void navigate({ search: (previous) => ({ ...previous, planId: item.id, areaId: item.areaId, weekId: item.weekId }) })}>
+                      <Button tone="secondary" onClick={() => void navigate({ search: (previous) => ({ ...previous, planId: item.id, areaId: item.areaId, weekId: undefined }) })}>
                         詳細
                       </Button>
                     </td>


### PR DESCRIPTION
Update the navigation logic to ensure that the weekId is cleared when a user selects plan details, improving the clarity of the displayed information.