### PR TITLE
feat: 共通循環レイアウト導入でローテーション位相を安定化し回帰テストを強化

### DIFF
--- a/osouji-touban-service/docs/application-usecase-design-v1.md
+++ b/osouji-touban-service/docs/application-usecase-design-v1.md
@@ -96,19 +96,19 @@
 2. `RebalanceForUserAssignedUseCase`
    - Input: `PlanId`, `AddedUserId`
    - Output: `Unit`
-   - SideEffect: 再配分計算、Plan再計算、Area cursor更新、イベント配送
+   - SideEffect: 共通循環位相で再配分計算（位相飛び最小化、同率時は history 公平補助）、Plan再計算、Area cursor更新、イベント配送
    - Error: `NotFound`, `InvalidRebalanceRequestError`, `WeekAlreadyClosedError`, `RepositoryConcurrency`
 
 3. `RebalanceForUserUnassignedUseCase`
    - Input: `PlanId`, `RemovedUserId`
    - Output: `Unit`
-   - SideEffect: 再配分計算、Plan再計算、Area cursor更新、イベント配送
+   - SideEffect: 共通循環位相で再配分計算（位相飛び最小化、同率時は history 公平補助）、Plan再計算、Area cursor更新、イベント配送
    - Error: `NotFound`, `InvalidRebalanceRequestError`, `WeekAlreadyClosedError`, `RepositoryConcurrency`
 
 4. `RecalculateForSpotChangedUseCase`
    - Input: `PlanId`
    - Output: `Unit`
-   - SideEffect: 再計算、Plan revision 増加、Area cursor更新、イベント配送
+   - SideEffect: 共通循環位相で再計算（位相飛び最小化）、Plan revision 増加、Area cursor更新、イベント配送
    - Error: `NotFound`, `InvalidRebalanceRequestError`, `WeekAlreadyClosedError`, `RepositoryConcurrency`
 
 5. `PublishWeeklyPlanUseCase`

--- a/osouji-touban-service/docs/core-domain-design-v3.md
+++ b/osouji-touban-service/docs/core-domain-design-v3.md
@@ -162,31 +162,34 @@
 1. 入力取得
    - `spots`（固定順）
    - `members`（社員番号昇順）
-   - `rotationCursor`
-   - `history[直近4週]`（担当回数、OffDuty連続回数）
+   - `rotationCursor`（共通循環列の開始位相）
+   - `history[直近4週]`（位相選択の同率時補助として使用）
 
-2. `spots >= members` の場合
-   - `rotationCursor` 起点の巡回で全 spot を順に割当。
-   - 余剰 spot は巡回継続で同一ユーザー複数担当可。
+2. 共通循環列の構築
+   - 全メンバーは同一の循環列を共有し、差分は開始位相のみ。
+    - `members.Count <= spots.Count` では `spot[i]` の担当者は `members[(phase + i) % members.Count]`。
+    - `members.Count > spots.Count` では、長さ `members.Count` の循環スロットに OffDuty を決定的に分散配置する。
+       - OffDuty 必要数 `k = members.Count - spots.Count`
+       - 位置 `p`（0-based）を OffDuty とする条件:
+          - `floor((p + 1) * k / members.Count) > floor(p * k / members.Count)`
+       - OffDuty でない位置に `spots` を昇順で詰める。
+   - `spots.Count > members.Count` の場合、巡回を継続して同一ユーザー複数担当を許容。
 
-3. `members > spots` の場合
-   - まず `spots` 人を担当者として選定。
-   - 残りを OffDuty 候補とする。
-   - OffDuty 決定規則:
-     - 連続 OffDuty 回避を最優先。
-     - 同率なら担当回数降順。
-     - それでも同率なら社員番号昇順。
+3. 連続同一 spot 割当の回避
+   - 週次生成 (`GenerateWeeklyPlan`) では `NextRotationCursor = (phase + 1) mod members.Count` とし、
+     複数メンバー時に同一 spot へ同一ユーザーが連続しないようにする。
 
-4. ユーザー追加（要件5）
-   - `spots > users_before_add` のとき、最多担当ユーザーから1件移譲。
-     - 最多担当同率は「現在担当件数降順 -> 過去4週担当回数降順 -> 社員番号昇順」。
-   - それ以外は当週は OffDuty（次回再計算で均衡）。
+4. Rebalance / Recalculate 時の位相選択
+   - 候補位相を全探索し、現在 `WeeklyDutyPlan.Assignments` と一致する spot-user 組が最大になる位相を選択。
+    - 一致数が同じ場合は `rotationCursor` からの循環距離が最小の位相を選択。
+    - 一致数・距離が同率の場合のみ、history 公平補助を適用する。
+       - `members > spots` では OffDuty になるユーザー集合の公平ペナルティが最小の位相を優先。
+    - さらに同率の場合は位相値が小さいものを選択。
+   - これにより、再配分・再計算時の位相飛びを最小化する。
 
-5. ユーザー離脱/異動（要件6）
-   - 離脱ユーザー担当なし: 変更なし。
-   - 担当あり:
-     - 当週 OffDuty ユーザー優先で補充。
-     - 不足時は通常ローテーションで補充。
+5. ユーザー追加 / 離脱 / Spot 増減
+   - いずれも上記「共通循環列 + 位相選択」へ統一して再計算。
+   - API 形状は維持し、再計算後は `WeeklyPlanRecalculated` を発行する。
 
 6. Spot 増減
    - 変更イベント受信で同週 `PlanRevision` を上げて再計算。

--- a/osouji-touban-service/src/OsoujiSystem.Application/UseCases/WeeklyDutyPlans/PlanComputationService.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Application/UseCases/WeeklyDutyPlans/PlanComputationService.cs
@@ -29,7 +29,6 @@ public sealed class PlanComputationService(
     {
         var histories = await LoadHistoriesAsync(area, plan.WeekId, plan.AssignmentPolicy.FairnessWindowWeeks, ct);
 
-        var usersBeforeAdd = Math.Max(0, area.Members.Count - 1);
         var input = new UserAssignedRebalanceInput(
             area.Spots,
             area.Members,
@@ -37,8 +36,7 @@ public sealed class PlanComputationService(
             histories,
             plan.Assignments,
             plan.OffDutyEntries,
-            addedUserId,
-            usersBeforeAdd);
+            addedUserId);
 
         return engine.RebalanceForUserAssigned(input);
     }
@@ -69,7 +67,7 @@ public sealed class PlanComputationService(
         CancellationToken ct)
     {
         var histories = await LoadHistoriesAsync(area, plan.WeekId, plan.AssignmentPolicy.FairnessWindowWeeks, ct);
-        return engine.Compute(area.Spots, area.Members, area.RotationCursor, histories);
+        return engine.RecalculateForSpotChanged(area.Spots, area.Members, area.RotationCursor, plan.Assignments, histories);
     }
 
     private Task<IReadOnlyDictionary<UserId, AssignmentHistorySnapshot>> LoadHistoriesAsync(

--- a/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/CommonRotationLayout.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/CommonRotationLayout.cs
@@ -1,0 +1,27 @@
+namespace OsoujiSystem.Domain.DomainServices;
+
+internal static class CommonRotationLayout
+{
+    public static int?[] BuildDistributedSlotLayout(int spotCount, int memberCount)
+    {
+        var offDutyCount = memberCount - spotCount;
+        var layout = new int?[memberCount];
+        var spotIndex = 0;
+
+        for (var position = 0; position < memberCount; position++)
+        {
+            var currentBucket = (position * offDutyCount) / memberCount;
+            var nextBucket = ((position + 1) * offDutyCount) / memberCount;
+            var isOffDutyPosition = nextBucket > currentBucket;
+
+            layout[position] = isOffDutyPosition ? null : spotIndex++;
+        }
+
+        return layout;
+    }
+
+    public static int ProjectedPosition(int memberIndex, int phase, int memberCount)
+    {
+        return ((memberIndex - phase) % memberCount + memberCount) % memberCount;
+    }
+}

--- a/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/DutyAssignmentEngine.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/DutyAssignmentEngine.cs
@@ -35,49 +35,17 @@ public sealed class DutyAssignmentEngine(FairnessPolicy fairnessPolicy)
             .OrderBy(member => member.EmployeeNumber)
             .ToArray();
 
-        var onDutyMembers = orderedMembers.AsEnumerable();
-        var offDutyEntries = new List<OffDutyEntry>();
-
-        if (orderedMembers.Length > orderedSpots.Length)
-        {
-            var selected = fairnessPolicy.SelectOnDutyMembers(
-                orderedMembers,
-                orderedSpots.Length,
-                histories);
-
-            onDutyMembers = selected;
-            var selectedUserIds = selected.Select(x => x.UserId).ToHashSet();
-
-            foreach (var member in orderedMembers.Where(x => !selectedUserIds.Contains(x.UserId)))
-            {
-                offDutyEntries.Add(new OffDutyEntry(member.UserId));
-            }
-        }
-
-        var onDutyArray = onDutyMembers.ToArray();
-        var assignments = new List<DutyAssignment>(orderedSpots.Length);
-        var memberIndex = onDutyArray.Length == 0
-            ? 0
-            : Math.Abs(rotationCursor.Value) % onDutyArray.Length;
-
-        foreach (var spot in orderedSpots)
-        {
-            if (onDutyArray.Length == 0)
-            {
-                return Result<AssignmentEngineResult, DomainError>.Failure(new NoAvailableUserForSpotError(spot.Id));
-            }
-
-            var member = onDutyArray[memberIndex];
-            assignments.Add(new DutyAssignment(spot.Id, member.UserId));
-            memberIndex = (memberIndex + 1) % onDutyArray.Length;
-        }
-
-        var nextCursor = onDutyArray.Length == 0
-            ? rotationCursor
-            : new RotationCursor((rotationCursor.Value + 1) % onDutyArray.Length);
+        var selectedPhase = fairnessPolicy.SelectClosestPhase(
+            orderedSpots,
+            orderedMembers,
+            rotationCursor,
+            [],
+            histories);
+        var projection = ProjectByPhase(orderedSpots, orderedMembers, selectedPhase.Value);
+        var nextCursor = selectedPhase.MoveNext(orderedMembers.Length);
 
         return Result<AssignmentEngineResult, DomainError>.Success(
-            new AssignmentEngineResult(assignments, offDutyEntries, nextCursor));
+            new AssignmentEngineResult(projection.Assignments, projection.OffDutyEntries, nextCursor));
     }
 
     public Result<AssignmentEngineResult, DomainError> RebalanceForUserAssigned(UserAssignedRebalanceInput input)
@@ -88,12 +56,6 @@ public sealed class DutyAssignmentEngine(FairnessPolicy fairnessPolicy)
             return Result<AssignmentEngineResult, DomainError>.Failure(commonValidation.Error);
         }
 
-        if (input.UsersBeforeAdd < 0)
-        {
-            return Result<AssignmentEngineResult, DomainError>.Failure(
-                new InvalidRebalanceRequestError("UsersBeforeAdd must be zero or more."));
-        }
-
         var addedMember = input.Members.FirstOrDefault(x => x.UserId == input.AddedUserId);
         if (addedMember is null)
         {
@@ -101,26 +63,27 @@ public sealed class DutyAssignmentEngine(FairnessPolicy fairnessPolicy)
                 new InvalidRebalanceRequestError("Added user must exist in current members."));
         }
 
-        if (input.Spots.Count > input.UsersBeforeAdd)
-        {
-            return TransferOneSpotToAddedUser(input);
-        }
+        var orderedSpots = input.Spots
+            .OrderBy(spot => spot.SortOrder)
+            .ThenBy(spot => spot.Name, StringComparer.Ordinal)
+            .ToArray();
 
-        var keptAssignments = input.CurrentAssignments
-            .Where(x => x.UserId != input.AddedUserId)
-            .ToList();
+        var orderedMembers = input.Members
+            .OrderBy(member => member.EmployeeNumber)
+            .ToArray();
 
-        var offDutyEntries = input.CurrentOffDutyEntries
-            .Where(x => x.UserId != input.AddedUserId)
-            .ToList();
+        var selectedPhase = fairnessPolicy.SelectClosestPhase(
+            orderedSpots,
+            orderedMembers,
+            input.RotationCursor,
+            input.CurrentAssignments,
+            input.Histories);
 
-        if (offDutyEntries.All(x => x.UserId != input.AddedUserId))
-        {
-            offDutyEntries.Add(new OffDutyEntry(input.AddedUserId));
-        }
+        var projection = ProjectByPhase(orderedSpots, orderedMembers, selectedPhase.Value);
+        var nextCursor = selectedPhase.MoveNext(orderedMembers.Length);
 
         return Result<AssignmentEngineResult, DomainError>.Success(
-            new AssignmentEngineResult(keptAssignments, offDutyEntries, input.RotationCursor));
+            new AssignmentEngineResult(projection.Assignments, projection.OffDutyEntries, nextCursor));
     }
 
     public Result<AssignmentEngineResult, DomainError> RebalanceForUserUnassigned(UserUnassignedRebalanceInput input)
@@ -131,72 +94,62 @@ public sealed class DutyAssignmentEngine(FairnessPolicy fairnessPolicy)
             return Result<AssignmentEngineResult, DomainError>.Failure(commonValidation.Error);
         }
 
-        var removedAssignments = input.CurrentAssignments
-            .Where(x => x.UserId == input.RemovedUserId)
-            .ToList();
-
-        var nextAssignments = input.CurrentAssignments
-            .Where(x => x.UserId != input.RemovedUserId)
-            .ToList();
-
-        var availableMembersByUserId = input.Members.ToDictionary(x => x.UserId, x => x);
-
-        var nextOffDuty = input.CurrentOffDutyEntries
-            .Where(x => x.UserId != input.RemovedUserId)
-            .Where(x => availableMembersByUserId.ContainsKey(x.UserId))
-            .ToList();
-
-        if (removedAssignments.Count == 0)
-        {
-            return Result<AssignmentEngineResult, DomainError>.Success(
-                new AssignmentEngineResult(nextAssignments, nextOffDuty, input.RotationCursor));
-        }
-
-        var usedOffDutyIds = new HashSet<UserId>();
-        var offDutyCandidates = nextOffDuty
-            .Select(x => x.UserId)
-            .Distinct()
-            .Select(id => availableMembersByUserId[id])
-            .OrderBy(x => x.EmployeeNumber)
-            .ToList();
-
-        var rotationCandidates = input.Members
-            .OrderBy(x => x.EmployeeNumber)
+        var orderedSpots = input.Spots
+            .OrderBy(spot => spot.SortOrder)
+            .ThenBy(spot => spot.Name, StringComparer.Ordinal)
             .ToArray();
 
-        if (rotationCandidates.Length == 0)
-        {
-            return Result<AssignmentEngineResult, DomainError>.Failure(new NoAvailableUserForSpotError(removedAssignments[0].SpotId));
-        }
+        var orderedMembers = input.Members
+            .OrderBy(member => member.EmployeeNumber)
+            .ToArray();
 
-        var spotOrder = input.Spots.ToDictionary(x => x.Id, x => (x.SortOrder, x.Name));
-        var rotationIndex = Math.Abs(input.RotationCursor.Value) % rotationCandidates.Length;
+        var selectedPhase = fairnessPolicy.SelectClosestPhase(
+            orderedSpots,
+            orderedMembers,
+            input.RotationCursor,
+            input.CurrentAssignments,
+            input.Histories);
 
-        foreach (var removedAssignment in removedAssignments.OrderBy(x => spotOrder[x.SpotId].SortOrder).ThenBy(x => spotOrder[x.SpotId].Name, StringComparer.Ordinal))
-        {
-            AreaMember selectedMember;
-            if (offDutyCandidates.Count > 0)
-            {
-                selectedMember = offDutyCandidates[0];
-                offDutyCandidates.RemoveAt(0);
-                usedOffDutyIds.Add(selectedMember.UserId);
-            }
-            else
-            {
-                selectedMember = rotationCandidates[rotationIndex];
-                rotationIndex = (rotationIndex + 1) % rotationCandidates.Length;
-            }
-
-            nextAssignments.Add(new DutyAssignment(removedAssignment.SpotId, selectedMember.UserId));
-        }
-
-        nextOffDuty = nextOffDuty
-            .Where(x => !usedOffDutyIds.Contains(x.UserId))
-            .ToList();
-
-        var nextCursor = new RotationCursor(rotationIndex);
+        var projection = ProjectByPhase(orderedSpots, orderedMembers, selectedPhase.Value);
+        var nextCursor = selectedPhase.MoveNext(orderedMembers.Length);
         return Result<AssignmentEngineResult, DomainError>.Success(
-            new AssignmentEngineResult(nextAssignments, nextOffDuty, nextCursor));
+            new AssignmentEngineResult(projection.Assignments, projection.OffDutyEntries, nextCursor));
+    }
+
+    public Result<AssignmentEngineResult, DomainError> RecalculateForSpotChanged(
+        IReadOnlyList<CleaningSpot> spots,
+        IReadOnlyList<AreaMember> members,
+        RotationCursor rotationCursor,
+        IReadOnlyList<DutyAssignment> currentAssignments,
+        IReadOnlyDictionary<UserId, AssignmentHistorySnapshot>? histories = null)
+    {
+        var commonValidation = ValidateCommonInput(spots, members);
+        if (commonValidation.IsFailure)
+        {
+            return Result<AssignmentEngineResult, DomainError>.Failure(commonValidation.Error);
+        }
+
+        var orderedSpots = spots
+            .OrderBy(spot => spot.SortOrder)
+            .ThenBy(spot => spot.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        var orderedMembers = members
+            .OrderBy(member => member.EmployeeNumber)
+            .ToArray();
+
+        var selectedPhase = fairnessPolicy.SelectClosestPhase(
+            orderedSpots,
+            orderedMembers,
+            rotationCursor,
+            currentAssignments,
+            histories);
+
+        var projection = ProjectByPhase(orderedSpots, orderedMembers, selectedPhase.Value);
+        var nextCursor = selectedPhase.MoveNext(orderedMembers.Length);
+
+        return Result<AssignmentEngineResult, DomainError>.Success(
+            new AssignmentEngineResult(projection.Assignments, projection.OffDutyEntries, nextCursor));
     }
 
     private Result<Unit, DomainError> ValidateCommonInput(
@@ -218,54 +171,69 @@ public sealed class DutyAssignmentEngine(FairnessPolicy fairnessPolicy)
         return Result<Unit, DomainError>.Success(Unit.Value);
     }
 
-    private Result<AssignmentEngineResult, DomainError> TransferOneSpotToAddedUser(UserAssignedRebalanceInput input)
+    private static AssignmentProjection ProjectByPhase(
+        IReadOnlyList<CleaningSpot> orderedSpots,
+        IReadOnlyList<AreaMember> orderedMembers,
+        int phase)
     {
-        var assignments = input.CurrentAssignments.ToList();
-        var donorCandidates = input.Members
-            .Where(x => x.UserId != input.AddedUserId)
-            .Select(member => new
-            {
-                Member = member,
-                CurrentAssignedCount = assignments.Count(x => x.UserId == member.UserId),
-                AssignedCountLast4Weeks = GetAssignedCount(member.UserId, input.Histories)
-            })
-            .Where(x => x.CurrentAssignedCount > 0)
-            .OrderByDescending(x => x.CurrentAssignedCount)
-            .ThenByDescending(x => x.AssignedCountLast4Weeks)
-            .ThenBy(x => x.Member.EmployeeNumber)
-            .ToList();
-
-        if (donorCandidates.Count == 0)
+        if (orderedMembers.Count > orderedSpots.Count)
         {
-            return Result<AssignmentEngineResult, DomainError>.Failure(
-                new InvalidRebalanceRequestError("No donor assignment exists for user assignment rebalance."));
+            return ProjectByDistributedOffDutyLayout(orderedSpots, orderedMembers, phase);
         }
 
-        var donorUserId = donorCandidates[0].Member.UserId;
-        var spotOrder = input.Spots.ToDictionary(x => x.Id, x => (x.SortOrder, x.Name));
-        var transferTarget = assignments
-            .Where(x => x.UserId == donorUserId)
-            .OrderBy(x => spotOrder[x.SpotId].SortOrder)
-            .ThenBy(x => spotOrder[x.SpotId].Name, StringComparer.Ordinal)
-            .First();
+        var assignments = new List<DutyAssignment>(orderedSpots.Count);
+        var offDutyEntries = new List<OffDutyEntry>();
 
-        assignments.Remove(transferTarget);
-        assignments.Add(new DutyAssignment(transferTarget.SpotId, input.AddedUserId));
+        for (var index = 0; index < orderedSpots.Count; index++)
+        {
+            var member = orderedMembers[(phase + index) % orderedMembers.Count];
+            assignments.Add(new DutyAssignment(orderedSpots[index].Id, member.UserId));
+        }
 
-        var offDutyEntries = input.CurrentOffDutyEntries
-            .Where(x => x.UserId != input.AddedUserId)
-            .ToList();
+        for (var index = orderedSpots.Count; index < orderedMembers.Count; index++)
+        {
+            var member = orderedMembers[(phase + index) % orderedMembers.Count];
+            offDutyEntries.Add(new OffDutyEntry(member.UserId));
+        }
 
-        return Result<AssignmentEngineResult, DomainError>.Success(
-            new AssignmentEngineResult(assignments, offDutyEntries, input.RotationCursor));
+        return new AssignmentProjection(assignments, offDutyEntries);
     }
 
-    private static int GetAssignedCount(
-        UserId userId,
-        IReadOnlyDictionary<UserId, AssignmentHistorySnapshot> histories)
+    private static AssignmentProjection ProjectByDistributedOffDutyLayout(
+        IReadOnlyList<CleaningSpot> orderedSpots,
+        IReadOnlyList<AreaMember> orderedMembers,
+        int phase)
     {
-        return histories.TryGetValue(userId, out var history)
-            ? history.AssignedCountLast4Weeks
-            : 0;
+        var layout = CommonRotationLayout.BuildDistributedSlotLayout(orderedSpots.Count, orderedMembers.Count);
+        var assignmentsBySpot = new DutyAssignment?[orderedSpots.Count];
+        var offDutyEntries = new List<OffDutyEntry>(orderedMembers.Count - orderedSpots.Count);
+
+        for (var memberIndex = 0; memberIndex < orderedMembers.Count; memberIndex++)
+        {
+            var projectedPosition = CommonRotationLayout.ProjectedPosition(memberIndex, phase, orderedMembers.Count);
+            var slot = layout[projectedPosition];
+            if (!slot.HasValue)
+            {
+                offDutyEntries.Add(new OffDutyEntry(orderedMembers[memberIndex].UserId));
+                continue;
+            }
+
+            assignmentsBySpot[slot.Value] = new DutyAssignment(
+                orderedSpots[slot.Value].Id,
+                orderedMembers[memberIndex].UserId);
+        }
+
+        var assignments = new List<DutyAssignment>(orderedSpots.Count);
+        for (var spotIndex = 0; spotIndex < orderedSpots.Count; spotIndex++)
+        {
+            assignments.Add(assignmentsBySpot[spotIndex]
+                ?? throw new InvalidOperationException($"Spot index {spotIndex} was not assigned."));
+        }
+
+        return new AssignmentProjection(assignments, offDutyEntries);
     }
+
+    private sealed record AssignmentProjection(
+        IReadOnlyList<DutyAssignment> Assignments,
+        IReadOnlyList<OffDutyEntry> OffDutyEntries);
 }

--- a/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/FairnessPolicy.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/FairnessPolicy.cs
@@ -1,4 +1,6 @@
 using OsoujiSystem.Domain.Entities.CleaningAreas;
+using OsoujiSystem.Domain.Entities.WeeklyDutyPlans;
+using OsoujiSystem.Domain.ValueObjects;
 
 namespace OsoujiSystem.Domain.DomainServices;
 
@@ -18,6 +20,119 @@ public sealed class FairnessPolicy
         return ordered.Take(requiredOnDutyCount).ToList();
     }
 
+    public RotationCursor SelectClosestPhase(
+        IReadOnlyList<CleaningSpot> orderedSpots,
+        IReadOnlyList<AreaMember> orderedMembers,
+        RotationCursor preferredPhase,
+        IReadOnlyList<DutyAssignment> currentAssignments,
+        IReadOnlyDictionary<UserId, AssignmentHistorySnapshot>? histories = null)
+    {
+        if (orderedMembers.Count == 0)
+        {
+            return preferredPhase;
+        }
+
+        histories ??= new Dictionary<UserId, AssignmentHistorySnapshot>();
+
+        var basePhase = new RotationCursor(preferredPhase.Normalize(orderedMembers.Count));
+        var currentBySpot = currentAssignments
+            .GroupBy(x => x.SpotId)
+            .ToDictionary(g => g.Key, g => g.First().UserId);
+
+        var bestPhase = 0;
+        var bestOverlap = int.MinValue;
+        var bestDistance = int.MaxValue;
+        var bestFairnessPenalty = int.MaxValue;
+
+        for (var candidate = 0; candidate < orderedMembers.Count; candidate++)
+        {
+            var overlap = 0;
+            if (orderedMembers.Count <= orderedSpots.Count)
+            {
+                for (var spotIndex = 0; spotIndex < orderedSpots.Count; spotIndex++)
+                {
+                    var spotId = orderedSpots[spotIndex].Id;
+                    var userId = orderedMembers[(candidate + spotIndex) % orderedMembers.Count].UserId;
+
+                    if (currentBySpot.TryGetValue(spotId, out var currentUserId) && currentUserId == userId)
+                    {
+                        overlap++;
+                    }
+                }
+            }
+            else
+            {
+                var layout = CommonRotationLayout.BuildDistributedSlotLayout(orderedSpots.Count, orderedMembers.Count);
+                for (var memberIndex = 0; memberIndex < orderedMembers.Count; memberIndex++)
+                {
+                    var projectedPosition = CommonRotationLayout.ProjectedPosition(memberIndex, candidate, orderedMembers.Count);
+                    var slot = layout[projectedPosition];
+                    if (!slot.HasValue)
+                    {
+                        continue;
+                    }
+
+                    var spotId = orderedSpots[slot.Value].Id;
+                    var userId = orderedMembers[memberIndex].UserId;
+                    if (currentBySpot.TryGetValue(spotId, out var currentUserId) && currentUserId == userId)
+                    {
+                        overlap++;
+                    }
+                }
+            }
+
+            var distance = basePhase.CircularDistanceTo(new RotationCursor(candidate), orderedMembers.Count);
+            var fairnessPenalty = ComputeOffDutyFairnessPenalty(
+                orderedSpots,
+                orderedMembers,
+                candidate,
+                histories);
+
+            if (overlap > bestOverlap
+                || (overlap == bestOverlap && distance < bestDistance)
+                || (overlap == bestOverlap && distance == bestDistance && fairnessPenalty < bestFairnessPenalty)
+                || (overlap == bestOverlap && distance == bestDistance && fairnessPenalty == bestFairnessPenalty && candidate < bestPhase))
+            {
+                bestPhase = candidate;
+                bestOverlap = overlap;
+                bestDistance = distance;
+                bestFairnessPenalty = fairnessPenalty;
+            }
+        }
+
+        return new RotationCursor(bestPhase);
+    }
+
+    private static int ComputeOffDutyFairnessPenalty(
+        IReadOnlyList<CleaningSpot> orderedSpots,
+        IReadOnlyList<AreaMember> orderedMembers,
+        int phase,
+        IReadOnlyDictionary<UserId, AssignmentHistorySnapshot> histories)
+    {
+        if (orderedMembers.Count <= orderedSpots.Count)
+        {
+            return 0;
+        }
+
+        var layout = CommonRotationLayout.BuildDistributedSlotLayout(orderedSpots.Count, orderedMembers.Count);
+        var penalty = 0;
+        for (var memberIndex = 0; memberIndex < orderedMembers.Count; memberIndex++)
+        {
+            var projectedPosition = CommonRotationLayout.ProjectedPosition(memberIndex, phase, orderedMembers.Count);
+            var isOffDuty = !layout[projectedPosition].HasValue;
+            if (!isOffDuty)
+            {
+                continue;
+            }
+
+            var member = orderedMembers[memberIndex];
+            var consecutiveOffDuty = GetConsecutiveOffDuty(member.UserId, histories);
+            var assignedCount = GetAssignedCount(member.UserId, histories);
+            penalty += (consecutiveOffDuty * 100) - assignedCount;
+        }
+
+        return penalty;
+    }
     private static int GetAssignedCount(
         UserId userId,
         IReadOnlyDictionary<UserId, AssignmentHistorySnapshot> histories)
@@ -36,3 +151,4 @@ public sealed class FairnessPolicy
             : 0;
     }
 }
+

--- a/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/RebalanceInputs.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Domain/DomainServices/RebalanceInputs.cs
@@ -11,8 +11,7 @@ public sealed record UserAssignedRebalanceInput(
     IReadOnlyDictionary<UserId, AssignmentHistorySnapshot> Histories,
     IReadOnlyList<DutyAssignment> CurrentAssignments,
     IReadOnlyList<OffDutyEntry> CurrentOffDutyEntries,
-    UserId AddedUserId,
-    int UsersBeforeAdd);
+    UserId AddedUserId);
 
 public sealed record UserUnassignedRebalanceInput(
     IReadOnlyList<CleaningSpot> Spots,

--- a/osouji-touban-service/src/OsoujiSystem.Domain/ValueObjects/RotationCursor.cs
+++ b/osouji-touban-service/src/OsoujiSystem.Domain/ValueObjects/RotationCursor.cs
@@ -16,7 +16,28 @@ public readonly record struct RotationCursor(int Value)
 
     public RotationCursor MoveNext(int modulo)
     {
-        return modulo <= 0 ? this : new RotationCursor((Value + 1) % modulo);
+        return modulo <= 0 ? this : new RotationCursor((Normalize(modulo) + 1) % modulo);
+    }
+
+    public int Normalize(int modulo)
+    {
+        return modulo <= 0
+            ? 0
+            : ((Value % modulo) + modulo) % modulo;
+    }
+
+    public int CircularDistanceTo(RotationCursor other, int modulo)
+    {
+        if (modulo <= 0)
+        {
+            return 0;
+        }
+
+        var from = Normalize(modulo);
+        var to = other.Normalize(modulo);
+        var forward = (to - from + modulo) % modulo;
+        var backward = (from - to + modulo) % modulo;
+        return Math.Min(forward, backward);
     }
 
     public override string ToString() => Value.ToString();

--- a/osouji-touban-service/tests/OsoujiSystem.Domain.Tests/DomainServices/DutyAssignmentEngineTests.cs
+++ b/osouji-touban-service/tests/OsoujiSystem.Domain.Tests/DomainServices/DutyAssignmentEngineTests.cs
@@ -60,12 +60,11 @@ public sealed class DutyAssignmentEngineTests
         var spotC = new CleaningSpot(CleaningSpotId.New(), "C", 1);
         var spots = new[] { spotB, spotA, spotC };
 
-        var histories = new Dictionary<UserId, AssignmentHistorySnapshot>();
         var sut = new DutyAssignmentEngine(new FairnessPolicy());
         var cursor = new RotationCursor(1);
 
         // Act
-        var result = sut.Compute(spots, members, cursor, histories);
+        var result = sut.Compute(spots, members, cursor, new Dictionary<UserId, AssignmentHistorySnapshot>());
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -107,7 +106,70 @@ public sealed class DutyAssignmentEngineTests
     }
 
     [Fact]
-    public void RebalanceForUserAssigned_WhenSpotsGreaterThanUsersBeforeAdd_ShouldTransferOneSpot()
+    public void Compute_WhenMembersAreMoreThanSpots_ShouldFollowCommonRotationPhase()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+        var members = new[] { member1, member2, member3 };
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+
+        var histories = new Dictionary<UserId, AssignmentHistorySnapshot>
+        {
+            [member1.UserId] = new AssignmentHistorySnapshot(member1.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member2.UserId] = new AssignmentHistorySnapshot(member2.UserId, AssignedCountLast4Weeks: 10, ConsecutiveOffDutyWeeks: 4),
+            [member3.UserId] = new AssignmentHistorySnapshot(member3.UserId, AssignedCountLast4Weeks: 1, ConsecutiveOffDutyWeeks: 1)
+        };
+
+        var sut = new DutyAssignmentEngine(new FairnessPolicy());
+
+        // Act
+        var result = sut.Compute([spot1, spot2], members, new RotationCursor(1), histories);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Assignments.Should().HaveCount(2);
+        result.Value.Assignments[0].UserId.Should().Be(member2.UserId);
+        result.Value.Assignments[1].UserId.Should().Be(member3.UserId);
+        result.Value.OffDutyEntries.Should().ContainSingle(x => x.UserId == member1.UserId);
+        result.Value.NextRotationCursor.Value.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compute_WhenCursorMovesNext_ShouldAvoidConsecutiveSameSpotAssignment()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+
+        var members = new[] { member1, member2, member3 };
+        var spots = new[] { spot1, spot2, spot3 };
+        var sut = new DutyAssignmentEngine(new FairnessPolicy());
+
+        // Act
+        var week1 = sut.Compute(spots, members, RotationCursor.Start, new Dictionary<UserId, AssignmentHistorySnapshot>());
+        var week2 = sut.Compute(spots, members, week1.Value.NextRotationCursor, new Dictionary<UserId, AssignmentHistorySnapshot>());
+
+        // Assert
+        week1.IsSuccess.Should().BeTrue();
+        week2.IsSuccess.Should().BeTrue();
+        week1.Value.Assignments.Should().HaveCount(3);
+        week2.Value.Assignments.Should().HaveCount(3);
+        week2.Value.Assignments.Should().OnlyContain(
+            assignment => week1.Value.Assignments.Any(
+                previous => previous.SpotId == assignment.SpotId && previous.UserId != assignment.UserId));
+    }
+
+    [Fact]
+    public void RebalanceForUserAssigned_WhenAddedUserCanBeScheduled_ShouldIncludeAddedUserInAssignments()
     {
         // Arrange
         var addedUser = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
@@ -144,17 +206,16 @@ public sealed class DutyAssignmentEngineTests
                 histories,
                 currentAssignments,
                 [],
-                addedUser.UserId,
-                UsersBeforeAdd: 2));
-
+                addedUser.UserId));
         // Assert
         result.IsSuccess.Should().BeTrue();
+        result.Value.Assignments.Should().HaveCount(spots.Length);
         result.Value.Assignments.Count(x => x.UserId == addedUser.UserId).Should().Be(1);
         result.Value.OffDutyEntries.Should().BeEmpty();
     }
 
     [Fact]
-    public void RebalanceForUserAssigned_WhenSpotsNotGreaterThanUsersBeforeAdd_ShouldMarkAddedUserOffDuty()
+    public void RebalanceForUserAssigned_WhenAddedUserCannotBeScheduled_ShouldMarkAddedUserOffDuty()
     {
         // Arrange
         var addedUser = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
@@ -182,9 +243,7 @@ public sealed class DutyAssignmentEngineTests
                 new Dictionary<UserId, AssignmentHistorySnapshot>(),
                 currentAssignments,
                 [],
-                addedUser.UserId,
-                UsersBeforeAdd: 2));
-
+                addedUser.UserId));
         // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.Assignments.Should().BeEquivalentTo(currentAssignments);
@@ -192,7 +251,7 @@ public sealed class DutyAssignmentEngineTests
     }
 
     [Fact]
-    public void RebalanceForUserUnassigned_WhenRemovedUserHasAssignments_ShouldFillFromOffDutyFirst()
+    public void RebalanceForUserUnassigned_WhenRemovedUserHasAssignments_ShouldReassignWithoutRemovedUser()
     {
         // Arrange
         var memberA = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
@@ -226,7 +285,174 @@ public sealed class DutyAssignmentEngineTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
+        result.Value.Assignments.Should().HaveCount(spots.Length);
         result.Value.Assignments.Where(x => x.UserId == memberC.UserId).Should().HaveCount(1);
         result.Value.Assignments.Should().NotContain(x => x.UserId == memberB.UserId);
+    }
+
+    [Fact]
+    public void RebalanceForUserAssigned_ShouldMinimizePhaseJumpUsingCommonRotation()
+    {
+        // Arrange
+        var memberA = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var memberB = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var addedMember = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+        var spots = new[] { spot1, spot2, spot3 };
+
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, memberA.UserId),
+            new DutyAssignment(spot2.Id, memberB.UserId),
+            new DutyAssignment(spot3.Id, memberA.UserId)
+        };
+
+        var sut = new DutyAssignmentEngine(new FairnessPolicy());
+
+        // Act
+        var result = sut.RebalanceForUserAssigned(
+            new UserAssignedRebalanceInput(
+                spots,
+                [memberA, memberB, addedMember],
+                new RotationCursor(1),
+                new Dictionary<UserId, AssignmentHistorySnapshot>(),
+                currentAssignments,
+                [],
+                addedMember.UserId));
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Assignments.Should().ContainSingle(x => x.SpotId == spot1.Id && x.UserId == memberA.UserId);
+        result.Value.Assignments.Should().ContainSingle(x => x.SpotId == spot2.Id && x.UserId == memberB.UserId);
+        result.Value.Assignments.Should().ContainSingle(x => x.SpotId == spot3.Id && x.UserId == addedMember.UserId);
+        result.Value.OffDutyEntries.Should().BeEmpty();
+        result.Value.NextRotationCursor.Value.Should().Be(1);
+    }
+
+    [Fact]
+    public void RecalculateForSpotChanged_ShouldAdvanceCursorFromSelectedPhase()
+    {
+        // Arrange
+        var memberA = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var memberB = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var memberC = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, memberB.UserId),
+            new DutyAssignment(spot2.Id, memberC.UserId),
+            new DutyAssignment(spot3.Id, memberA.UserId)
+        };
+
+        var sut = new DutyAssignmentEngine(new FairnessPolicy());
+
+        // Act
+        var result = sut.RecalculateForSpotChanged(
+            [spot1, spot2, spot3],
+            [memberA, memberB, memberC],
+            new RotationCursor(1),
+            currentAssignments);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Assignments.Should().ContainSingle(x => x.SpotId == spot1.Id && x.UserId == memberB.UserId);
+        result.Value.Assignments.Should().ContainSingle(x => x.SpotId == spot2.Id && x.UserId == memberC.UserId);
+        result.Value.Assignments.Should().ContainSingle(x => x.SpotId == spot3.Id && x.UserId == memberA.UserId);
+        result.Value.OffDutyEntries.Should().BeEmpty();
+        result.Value.NextRotationCursor.Value.Should().Be(2);
+    }
+
+    [Fact]
+    public void Compute_WhenUsersExceedSpots_ShouldKeepSingleSharedSequenceAndAdvancePhaseOneStep()
+    {
+        // Arrange
+        var members = Enumerable.Range(1, 9)
+            .Select(i => new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo($"{i:000000}")))
+            .ToArray();
+
+        var spots = new[]
+        {
+            new CleaningSpot(CleaningSpotId.New(), "A", 1),
+            new CleaningSpot(CleaningSpotId.New(), "B", 2),
+            new CleaningSpot(CleaningSpotId.New(), "C", 3),
+            new CleaningSpot(CleaningSpotId.New(), "D", 4),
+            new CleaningSpot(CleaningSpotId.New(), "E", 5),
+            new CleaningSpot(CleaningSpotId.New(), "F", 6)
+        };
+
+        var sut = new DutyAssignmentEngine(new FairnessPolicy());
+        var cursor = RotationCursor.Start;
+        var orderedMemberIds = members
+            .OrderBy(x => x.EmployeeNumber)
+            .Select(x => x.UserId)
+            .ToArray();
+        var weeklyStateVectors = new List<string[]>();
+
+        // Act
+        for (var week = 0; week < 9; week++)
+        {
+            var result = sut.Compute(spots, members, cursor, new Dictionary<UserId, AssignmentHistorySnapshot>());
+            result.IsSuccess.Should().BeTrue();
+
+            var stateByUser = GetStateByUser(result.Value.Assignments, result.Value.OffDutyEntries, spots);
+            weeklyStateVectors.Add(orderedMemberIds.Select(userId => stateByUser[userId]).ToArray());
+
+            cursor = result.Value.NextRotationCursor;
+        }
+
+        // Assert
+        for (var week = 1; week < weeklyStateVectors.Count; week++)
+        {
+            IsRotatedRightByOne(weeklyStateVectors[week - 1], weeklyStateVectors[week]).Should().BeTrue();
+        }
+
+        var offDutyCountByWeek = weeklyStateVectors.Select(weekStates => weekStates.Count(state => state == "OFF"));
+        offDutyCountByWeek.Should().OnlyContain(count => count == 3);
+    }
+
+    private static Dictionary<UserId, string> GetStateByUser(
+        IReadOnlyList<DutyAssignment> assignments,
+        IReadOnlyList<OffDutyEntry> offDutyEntries,
+        IReadOnlyList<CleaningSpot> spots)
+    {
+        var spotNameById = spots.ToDictionary(x => x.Id, x => x.Name);
+        var states = new Dictionary<UserId, string>();
+
+        foreach (var assignment in assignments)
+        {
+            states[assignment.UserId] = spotNameById[assignment.SpotId];
+        }
+
+        foreach (var offDuty in offDutyEntries)
+        {
+            states[offDuty.UserId] = "OFF";
+        }
+
+        return states;
+    }
+
+    private static bool IsRotatedRightByOne(IReadOnlyList<string> previous, IReadOnlyList<string> current)
+    {
+        if (previous.Count != current.Count)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < previous.Count; index++)
+        {
+            var previousIndex = (index - 1 + previous.Count) % previous.Count;
+            if (current[index] != previous[previousIndex])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/osouji-touban-service/tests/OsoujiSystem.Domain.Tests/DomainServices/FairnessPolicyTests.cs
+++ b/osouji-touban-service/tests/OsoujiSystem.Domain.Tests/DomainServices/FairnessPolicyTests.cs
@@ -1,6 +1,8 @@
 using AwesomeAssertions;
 using OsoujiSystem.Domain.DomainServices;
 using OsoujiSystem.Domain.Entities.CleaningAreas;
+using OsoujiSystem.Domain.Entities.WeeklyDutyPlans;
+using OsoujiSystem.Domain.ValueObjects;
 
 namespace OsoujiSystem.Domain.Tests.DomainServices;
 
@@ -61,5 +63,272 @@ public sealed class FairnessPolicyTests
 
         // Assert
         selected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectClosestPhase_ShouldPrioritizeAssignmentOverlapThenDistance()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, member1.UserId),
+            new DutyAssignment(spot2.Id, member2.UserId),
+            new DutyAssignment(spot3.Id, member1.UserId)
+        };
+
+        var sut = new FairnessPolicy();
+
+        // Act
+        var phase = sut.SelectClosestPhase(
+            [spot1, spot2, spot3],
+            [member1, member2, member3],
+            new RotationCursor(1),
+            currentAssignments);
+
+        // Assert
+        phase.Value.Should().Be(0);
+    }
+
+    [Fact]
+    public void SelectClosestPhase_WhenOverlapAndDistanceTie_ShouldUseHistoryAsTieBreaker()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+        var member4 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000004"));
+        var member5 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000005"));
+        var member6 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000006"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+        var spot4 = new CleaningSpot(CleaningSpotId.New(), "D", 4);
+
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, member2.UserId),
+            new DutyAssignment(spot2.Id, member1.UserId),
+            new DutyAssignment(spot3.Id, member2.UserId),
+            new DutyAssignment(spot4.Id, member2.UserId)
+        };
+
+        var histories = new Dictionary<UserId, AssignmentHistorySnapshot>
+        {
+            [member1.UserId] = new AssignmentHistorySnapshot(member1.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 5),
+            [member2.UserId] = new AssignmentHistorySnapshot(member2.UserId, AssignedCountLast4Weeks: 4, ConsecutiveOffDutyWeeks: 0),
+            [member3.UserId] = new AssignmentHistorySnapshot(member3.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member4.UserId] = new AssignmentHistorySnapshot(member4.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 5),
+            [member5.UserId] = new AssignmentHistorySnapshot(member5.UserId, AssignedCountLast4Weeks: 4, ConsecutiveOffDutyWeeks: 0),
+            [member6.UserId] = new AssignmentHistorySnapshot(member6.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0)
+        };
+
+        var sut = new FairnessPolicy();
+
+        // Act
+        var phase = sut.SelectClosestPhase(
+            [spot1, spot2, spot3, spot4],
+            [member1, member2, member3, member4, member5, member6],
+            RotationCursor.Start,
+            currentAssignments,
+            histories);
+
+        // Assert
+        phase.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void SelectClosestPhase_WhenOverlapTies_ShouldPreferSmallerDistanceEvenIfHistoryPenaltyIsWorse()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+        var member4 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000004"));
+        var member5 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000005"));
+        var member6 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000006"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+        var spot4 = new CleaningSpot(CleaningSpotId.New(), "D", 4);
+
+        // candidate=5 と candidate=4 が overlap=1 で同点になり、distance は 5(1) < 4(2)
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, member6.UserId),
+            new DutyAssignment(spot2.Id, member1.UserId),
+            new DutyAssignment(spot3.Id, member1.UserId),
+            new DutyAssignment(spot4.Id, member3.UserId)
+        };
+
+        // candidate=5 側の off-duty を重くしても、distance 優先で candidate=5 が選ばれることを確認
+        var histories = new Dictionary<UserId, AssignmentHistorySnapshot>
+        {
+            [member1.UserId] = new AssignmentHistorySnapshot(member1.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member2.UserId] = new AssignmentHistorySnapshot(member2.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 8),
+            [member3.UserId] = new AssignmentHistorySnapshot(member3.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member4.UserId] = new AssignmentHistorySnapshot(member4.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member5.UserId] = new AssignmentHistorySnapshot(member5.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 8),
+            [member6.UserId] = new AssignmentHistorySnapshot(member6.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0)
+        };
+
+        var sut = new FairnessPolicy();
+
+        // Act
+        var phase = sut.SelectClosestPhase(
+            [spot1, spot2, spot3, spot4],
+            [member1, member2, member3, member4, member5, member6],
+            RotationCursor.Start,
+            currentAssignments,
+            histories);
+
+        // Assert
+        phase.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void SelectClosestPhase_WhenOverlapAndDistanceTie_ShouldPreferLowerHistoryPenaltyOverSmallerPhase()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+        var member4 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000004"));
+        var member5 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000005"));
+        var member6 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000006"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+        var spot4 = new CleaningSpot(CleaningSpotId.New(), "D", 4);
+
+        // candidate=1 と candidate=5 が overlap=1, distance=1 で同点になる配置
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, member2.UserId),
+            new DutyAssignment(spot2.Id, member1.UserId),
+            new DutyAssignment(spot3.Id, member1.UserId),
+            new DutyAssignment(spot4.Id, member1.UserId)
+        };
+
+        // candidate=1 の off-duty(member1, member4)を重くして、candidate=5 の方を有利にする
+        var histories = new Dictionary<UserId, AssignmentHistorySnapshot>
+        {
+            [member1.UserId] = new AssignmentHistorySnapshot(member1.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 8),
+            [member2.UserId] = new AssignmentHistorySnapshot(member2.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member3.UserId] = new AssignmentHistorySnapshot(member3.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member4.UserId] = new AssignmentHistorySnapshot(member4.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 8),
+            [member5.UserId] = new AssignmentHistorySnapshot(member5.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member6.UserId] = new AssignmentHistorySnapshot(member6.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0)
+        };
+
+        var sut = new FairnessPolicy();
+
+        // Act
+        var phase = sut.SelectClosestPhase(
+            [spot1, spot2, spot3, spot4],
+            [member1, member2, member3, member4, member5, member6],
+            RotationCursor.Start,
+            currentAssignments,
+            histories);
+
+        // Assert
+        phase.Value.Should().Be(5);
+    }
+
+    [Fact]
+    public void SelectClosestPhase_WhenOverlapDistanceAndHistoryTie_ShouldPickSmallerPhase()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+        var member4 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000004"));
+        var member5 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000005"));
+        var member6 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000006"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+        var spot4 = new CleaningSpot(CleaningSpotId.New(), "D", 4);
+
+        // candidate=1 と candidate=5 を overlap=1, distance=1 で同点にする
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, member2.UserId),
+            new DutyAssignment(spot2.Id, member1.UserId),
+            new DutyAssignment(spot3.Id, member1.UserId),
+            new DutyAssignment(spot4.Id, member1.UserId)
+        };
+
+        // 全員同一履歴にして fairness penalty を同点化し、最終タイブレーク(phase小)を確認
+        var histories = new Dictionary<UserId, AssignmentHistorySnapshot>
+        {
+            [member1.UserId] = new AssignmentHistorySnapshot(member1.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member2.UserId] = new AssignmentHistorySnapshot(member2.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member3.UserId] = new AssignmentHistorySnapshot(member3.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member4.UserId] = new AssignmentHistorySnapshot(member4.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member5.UserId] = new AssignmentHistorySnapshot(member5.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0),
+            [member6.UserId] = new AssignmentHistorySnapshot(member6.UserId, AssignedCountLast4Weeks: 0, ConsecutiveOffDutyWeeks: 0)
+        };
+
+        var sut = new FairnessPolicy();
+
+        // Act
+        var phase = sut.SelectClosestPhase(
+            [spot1, spot2, spot3, spot4],
+            [member1, member2, member3, member4, member5, member6],
+            RotationCursor.Start,
+            currentAssignments,
+            histories);
+
+        // Assert
+        phase.Value.Should().Be(1);
+    }
+
+    [Fact]
+    public void SelectClosestPhase_WhenMembersExceedSpots_ShouldUseDistributedProjectionForOverlap()
+    {
+        // Arrange
+        var member1 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000001"));
+        var member2 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000002"));
+        var member3 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000003"));
+        var member4 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000004"));
+        var member5 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000005"));
+        var member6 = new AreaMember(AreaMemberId.New(), UserId.New(), TestDataFactory.EmployeeNo("000006"));
+
+        var spot1 = new CleaningSpot(CleaningSpotId.New(), "A", 1);
+        var spot2 = new CleaningSpot(CleaningSpotId.New(), "B", 2);
+        var spot3 = new CleaningSpot(CleaningSpotId.New(), "C", 3);
+        var spot4 = new CleaningSpot(CleaningSpotId.New(), "D", 4);
+
+        var currentAssignments = new[]
+        {
+            new DutyAssignment(spot1.Id, member2.UserId),
+            new DutyAssignment(spot2.Id, member3.UserId),
+            new DutyAssignment(spot3.Id, member5.UserId),
+            new DutyAssignment(spot4.Id, member6.UserId)
+        };
+
+        var sut = new FairnessPolicy();
+
+        // Act
+        var phase = sut.SelectClosestPhase(
+            [spot1, spot2, spot3, spot4],
+            [member1, member2, member3, member4, member5, member6],
+            new RotationCursor(2),
+            currentAssignments);
+
+        // Assert
+        phase.Value.Should().Be(1);
     }
 }

--- a/osouji-touban-service/tests/OsoujiSystem.Domain.Tests/ValueObjects/ValueObjectsTests.cs
+++ b/osouji-touban-service/tests/OsoujiSystem.Domain.Tests/ValueObjects/ValueObjectsTests.cs
@@ -245,4 +245,31 @@ public sealed class RotationCursorTests
         // Assert
         next.Value.Should().Be(0);
     }
+
+    [Fact]
+    public void Normalize_WhenNegativeValue_ShouldWrapToPositivePhase()
+    {
+        // Arrange
+        var cursor = new RotationCursor(-1);
+
+        // Act
+        var normalized = cursor.Normalize(3);
+
+        // Assert
+        normalized.Should().Be(2);
+    }
+
+    [Fact]
+    public void CircularDistanceTo_ShouldReturnShortestDistance()
+    {
+        // Arrange
+        var from = new RotationCursor(0);
+        var to = new RotationCursor(3);
+
+        // Act
+        var distance = from.CircularDistanceTo(to, 4);
+
+        // Assert
+        distance.Should().Be(1);
+    }
 }


### PR DESCRIPTION
## Why
- 掃除当番ローテーションで、全員が同一シーケンスを位相差だけで辿る仕様を安定して担保するため
- Rebalanceおよび再計算時の位相ジャンプを抑え、回帰をテストで早期検知するため

## What
- OffDuty分散レイアウト計算を共通化し CommonRotationLayout を新設
- DutyAssignmentEngine と FairnessPolicy で共通利用
- RebalanceInputs から実質未使用の UsersBeforeAdd を削除
- DutyAssignmentEngineTests のテスト名と検証内容の整合を改善
- FairnessPolicyTests に同点境界ケースを追加
  - overlap -> distance -> history penalty -> phase小 の優先順位を検証
- 関連ドキュメントを更新

## Test Result
- dotnet restore: 成功
- dotnet build: 成功
- dotnet test: 成功（206 passed, 0 failed）

## Risk and Impact
- 主な影響範囲はドメイン層の割当ロジック（再配分・再計算）とそのテスト
- API入出力契約は維持
- 位相選択ロジック変更による割当差分リスクはあるが、同点境界ケースを含むテスト追加で検知力を強化

Closes #37
