### PR TITLE
feat: Issue #42 既存アサイン済みメンバーのDisplayNameバックフィル

### DIFF
--- a/osouji-touban-service/docs/api-endpoint-design-v1.md
+++ b/osouji-touban-service/docs/api-endpoint-design-v1.md
@@ -172,6 +172,51 @@
 
 `members[*].displayName` は nullable。ユーザー表示名が read model に未反映または未設定の場合、`null` を返しうる。
 
+運用上は `0010_backfill_area_member_display_name.sql` により、active member の `displayName` 欠損を補完できる。補完優先順位は `user_id` 一致を優先し、次点で `employee_number` 一意一致を利用する。`employee_number` が複数一致する場合は補完せず、既存の有効な `displayName` は上書きしない。
+
+`0010_backfill_area_member_display_name.sql` 実行時は、以下の観測値が `migration_area_member_display_name_backfill_runs` に 1 行記録される。
+
+- `target_member_count`: 対象 active member 件数
+- `updated_member_count`: display_name 更新/挿入件数
+- `unresolved_member_count`: 実行後も display_name 欠損の件数
+- `ambiguous_match_count`: employee_number 候補が複数で補完を見送った件数
+- `missing_rate_before`, `missing_rate_after`: 欠損率の実行前後
+
+運用確認クエリ例:
+
+```sql
+SELECT
+   run_id,
+   target_member_count,
+   updated_member_count,
+   unresolved_member_count,
+   ambiguous_match_count,
+   missing_rate_before,
+   missing_rate_after,
+   executed_at
+FROM migration_area_member_display_name_backfill_runs
+ORDER BY run_id DESC
+LIMIT 5;
+```
+
+### 3.2.1. migration 後のキャッシュ反映運用
+
+`0010_backfill_area_member_display_name.sql` は projection table を直接更新するため、イベント経由の read-model cache invalidation は発火しない。表示改善を即時確認したい場合は、以下のいずれかを実施する。
+
+1. Redis キャッシュを明示的に無効化する（推奨）
+  - 例: 対象環境 Redis に対して `FLUSHDB` または運用手順で定義済みの key pattern 削除を実行
+  - 実行後に `GET /api/v1/cleaning-areas/{areaId}` を再取得して `members[*].displayName` を確認
+2. 即時無効化を行わない場合
+  - `Infrastructure:Redis:ReadModelDetailTtlSeconds`（既定 86400 秒）以内は旧表示が残りうる
+  - TTL 経過後に自動的に再読込される
+
+実行直後の確認手順:
+
+1. migration 実行
+2. `migration_area_member_display_name_backfill_runs` を確認し、`updated_member_count > 0` と `missing_rate_after <= missing_rate_before` を確認
+3. Redis 無効化を実施
+4. 代表エリアの `GET /api/v1/cleaning-areas/{areaId}` で表示名改善を確認
+
 ### 3.3. WeeklyDutyPlan
 
 ```json

--- a/osouji-touban-service/docs/issue-42-reflection.md
+++ b/osouji-touban-service/docs/issue-42-reflection.md
@@ -1,0 +1,121 @@
+# Issue #42 振り返り: 既存アサイン済みメンバー displayName バックフィル
+
+## 1. 実装の背景と目的
+
+Issue #42 では、Issue #40 で ReadModel 取得時の JOIN 改善を入れた後も、既存のアサイン済みメンバーに displayName 欠損が残り、UI 上で社員番号フォールバック表示が継続していた問題を扱った。
+
+目的は以下の 3 点。
+
+- 既存データに対して安全に displayName を補完する
+- 再実行しても不整合を起こさない idempotent なバックフィルを提供する
+- 実行結果を定量的に追跡できるよう、可観測性を担保する
+
+## 2. 意思決定と実装方針
+
+今回の設計上の主要な意思決定は次のとおり。
+
+- 解決優先順位を明示
+  - 第一候補: user_id 一致
+  - 第二候補: employee_number 一致
+- employee_number で複数候補が存在する曖昧ケースは更新しない
+  - 誤更新リスクを避けるため、補完可能性より正確性を優先
+- display_name は空文字・空白を正規化して扱う
+- UPSERT 条件を限定し、既存の有効 display_name を劣化上書きしない
+- 実行ごとにメトリクスを記録し、欠損率の前後比較を可能にする
+
+## 3. 実装内容とポイント
+
+### 3.1 Migration 0010 の追加
+
+対象: src/OsoujiSystem.Infrastructure/Migrations/0010_backfill_area_member_display_name.sql
+
+実装ポイント:
+
+- active member を対象にバックフィル候補を作成
+- user_id で displayName を解決できる場合は最優先で採用
+- user_id で解決不能な場合のみ employee_number で補完候補を探索
+- employee_number 側で候補が複数になる場合は曖昧扱いとして不更新
+- projection_user_directory への INSERT/ON CONFLICT UPDATE により idempotent に適用
+- UPDATE 条件で既存 display_name が空の場合のみに限定し、既存有効値を保護
+
+### 3.2 可観測性の追加
+
+Migration 内で以下を実施。
+
+- 実行結果テーブル migration_area_member_display_name_backfill_runs を作成
+- 指標を run ごとに記録
+  - target_member_count
+  - updated_member_count
+  - unresolved_member_count
+  - ambiguous_match_count
+  - missing_rate_before
+  - missing_rate_after
+- 最終的な実行結果を NOTICE として出力し、運用時に即時確認可能化
+
+### 3.3 テストと docs 更新
+
+入力情報ベースで、以下を実施済み。
+
+- API 統合テストを追加し、補完後の displayName 取得挙動を検証
+- docs を更新し、バックフィル方針と運用観点を反映
+
+## 4. テスト結果
+
+- dotnet test: 216/216 success
+
+本変更により、機能追加後の回帰が発生していないことを確認した。
+
+## 5. コードレビュー指摘と対応
+
+レビュー結果:
+
+- PR ブロッカー: なし
+- Medium 指摘: migration 内の通常 CREATE INDEX による運用ロックリスク
+
+対応状況:
+
+- 現時点では CREATE INDEX IF NOT EXISTS を採用し、重複作成は防止
+- ただし通常 CREATE INDEX はテーブル書き込みをブロックしうるため、運用上の注意として明示
+- 実運用では以下を推奨
+  - 低トラフィック帯で migration を適用
+  - 必要に応じて事前に別手順で index 作成を実施
+  - 監視でロック待ち/遅延を観測し、適用ウィンドウを再調整
+
+## 6. 残リスクと運用注意
+
+残リスク:
+
+- employee_number のデータ品質が低い環境では未解決件数が残る
+- 曖昧一致を不更新にしているため、欠損率を 0 にできないケースがある
+- index 作成タイミング次第で一時的なロック影響が出る可能性がある
+
+運用注意:
+
+- migration_area_member_display_name_backfill_runs の before/after 指標を run ごとに確認
+- unresolved_member_count と ambiguous_match_count が高い場合は、元データ補正計画を別途立てる
+- 再実行時も idempotent であることを前提に、段階的適用と観測を行う
+
+## 7. 学びと改善点
+
+学び:
+
+- バックフィルは「更新率最大化」より「誤更新回避」を優先する設計が重要
+- SQL migration でも可観測性を内包すると、運用判断と障害切り分けが速くなる
+- idempotency と更新ガードの両立が、本番再実行可能性を高める
+
+改善できる点:
+
+- index ロック影響をさらに抑える運用設計（適用順序・時間帯・監視手順）の標準化
+- 曖昧一致の未解決を減らすためのデータ品質改善プロセス（社員番号マスタ整備など）
+- バックフィル run 指標のダッシュボード化としきい値アラート整備
+
+## 8. 完了判定
+
+Issue #42 の目的に対し、以下を満たした。
+
+- user_id 優先・employee_number 次点の補完ルール実装
+- 曖昧一致の不更新方針実装
+- idempotent なバックフィル実装
+- 可観測化メトリクス記録実装
+- API 統合テスト追加と docs 更新
+- テスト全件成功 (216/216)

--- a/osouji-touban-service/src/OsoujiSystem.Infrastructure/Migrations/0010_backfill_area_member_display_name.sql
+++ b/osouji-touban-service/src/OsoujiSystem.Infrastructure/Migrations/0010_backfill_area_member_display_name.sql
@@ -1,0 +1,165 @@
+CREATE INDEX IF NOT EXISTS ix_projection_user_directory_employee_number_nonblank_display_name
+    ON projection_user_directory (employee_number)
+    WHERE NULLIF(BTRIM(display_name), '') IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS migration_area_member_display_name_backfill_runs (
+    run_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    target_member_count BIGINT NOT NULL,
+    updated_member_count BIGINT NOT NULL,
+    unresolved_member_count BIGINT NOT NULL,
+    ambiguous_match_count BIGINT NOT NULL,
+    missing_rate_before NUMERIC(8, 6) NOT NULL,
+    missing_rate_after NUMERIC(8, 6) NOT NULL,
+    executed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+WITH normalized_user_directory AS (
+    SELECT
+        p.user_id,
+        p.employee_number,
+        NULLIF(BTRIM(p.display_name), '') AS normalized_display_name
+    FROM projection_user_directory p
+),
+active_members AS (
+    SELECT
+        m.user_id,
+        m.employee_number
+    FROM projection_area_members m
+    WHERE m.is_active = true
+),
+employee_directory_resolution AS (
+    SELECT
+        d.employee_number,
+        COUNT(*) FILTER (WHERE d.normalized_display_name IS NOT NULL) AS candidate_count,
+        CASE
+            WHEN COUNT(*) FILTER (WHERE d.normalized_display_name IS NOT NULL) = 1
+                THEN MAX(d.normalized_display_name)
+            ELSE NULL
+        END AS unique_display_name
+    FROM normalized_user_directory d
+    GROUP BY d.employee_number
+),
+member_backfill_candidates AS (
+    SELECT
+        m.user_id,
+        m.employee_number,
+        u.normalized_display_name AS user_id_display_name,
+        COALESCE(e.candidate_count, 0) AS employee_candidate_count,
+        e.unique_display_name AS employee_unique_display_name,
+        COALESCE(u.normalized_display_name, e.unique_display_name) AS backfilled_display_name
+    FROM active_members m
+    LEFT JOIN normalized_user_directory u ON u.user_id = m.user_id
+    LEFT JOIN employee_directory_resolution e ON e.employee_number = m.employee_number
+),
+pre_metrics AS (
+    SELECT
+        COUNT(*) AS target_member_count,
+        COUNT(*) FILTER (WHERE c.user_id_display_name IS NULL) AS missing_before_count,
+        COUNT(*) FILTER (
+            WHERE c.user_id_display_name IS NULL
+              AND c.employee_candidate_count > 1
+        ) AS ambiguous_match_count
+    FROM member_backfill_candidates c
+),
+upserted AS (
+    INSERT INTO projection_user_directory (
+        user_id,
+        employee_number,
+        display_name,
+        lifecycle_status,
+        department_code,
+        source_event_id,
+        aggregate_version,
+        email_address,
+        updated_at
+    )
+    SELECT
+        c.user_id,
+        c.employee_number,
+        c.backfilled_display_name,
+        'Active',
+        '',
+        gen_random_uuid(),
+        1,
+        NULL,
+        now()
+    FROM member_backfill_candidates c
+    WHERE c.user_id_display_name IS NULL
+      AND c.backfilled_display_name IS NOT NULL
+    ON CONFLICT (user_id)
+    DO UPDATE SET
+        display_name = EXCLUDED.display_name,
+        updated_at = now()
+    WHERE NULLIF(BTRIM(projection_user_directory.display_name), '') IS NULL
+      AND NULLIF(BTRIM(EXCLUDED.display_name), '') IS NOT NULL
+    RETURNING projection_user_directory.user_id
+),
+final_metrics AS (
+    SELECT
+        pm.target_member_count,
+        updates.updated_member_count,
+        GREATEST(pm.missing_before_count - updates.updated_member_count, 0) AS unresolved_member_count,
+        pm.ambiguous_match_count,
+        CASE
+            WHEN pm.target_member_count = 0 THEN 0::numeric
+            ELSE pm.missing_before_count::numeric / pm.target_member_count::numeric
+        END AS missing_rate_before,
+        CASE
+            WHEN pm.target_member_count = 0 THEN 0::numeric
+            ELSE GREATEST(pm.missing_before_count - updates.updated_member_count, 0)::numeric
+                 / pm.target_member_count::numeric
+        END AS missing_rate_after
+    FROM pre_metrics pm
+    CROSS JOIN (
+        SELECT COUNT(*) AS updated_member_count
+        FROM upserted
+    ) AS updates
+)
+INSERT INTO migration_area_member_display_name_backfill_runs (
+    target_member_count,
+    updated_member_count,
+    unresolved_member_count,
+    ambiguous_match_count,
+    missing_rate_before,
+    missing_rate_after,
+    executed_at
+)
+SELECT
+    f.target_member_count,
+    f.updated_member_count,
+    f.unresolved_member_count,
+    f.ambiguous_match_count,
+    f.missing_rate_before,
+    f.missing_rate_after,
+    now()
+FROM final_metrics f;
+
+DO $$
+DECLARE
+    metrics RECORD;
+BEGIN
+    SELECT
+        run_id,
+        target_member_count,
+        updated_member_count,
+        unresolved_member_count,
+        ambiguous_match_count,
+        missing_rate_before,
+        missing_rate_after,
+        executed_at
+    INTO metrics
+    FROM migration_area_member_display_name_backfill_runs
+    ORDER BY run_id DESC
+    LIMIT 1;
+
+    RAISE NOTICE
+        '0010_backfill_area_member_display_name run_id=% target=% updated=% unresolved=% ambiguous=% missing_before=% missing_after=% executed_at=%',
+        metrics.run_id,
+        metrics.target_member_count,
+        metrics.updated_member_count,
+        metrics.unresolved_member_count,
+        metrics.ambiguous_match_count,
+        metrics.missing_rate_before,
+        metrics.missing_rate_after,
+        metrics.executed_at;
+END $$;

--- a/osouji-touban-service/tests/OsoujiSystem.WebApi.Tests/ApiIntegrationTestFixture.cs
+++ b/osouji-touban-service/tests/OsoujiSystem.WebApi.Tests/ApiIntegrationTestFixture.cs
@@ -67,6 +67,7 @@ public sealed class ApiIntegrationTestFixture : IAsyncLifetime
 
     private ConnectionMultiplexer? _redisConnection;
     private readonly Dictionary<string, string?> _previousEnvironment = [];
+    private readonly string _repositoryRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
 
     public CustomWebApplicationFactory Factory { get; private set; } = null!;
 
@@ -248,6 +249,46 @@ public sealed class ApiIntegrationTestFixture : IAsyncLifetime
         }
 
         ArgumentNullException.ThrowIfNull(_redisConnection);
+        foreach (var endpoint in _redisConnection.GetEndPoints())
+        {
+            var server = _redisConnection.GetServer(endpoint);
+            await server.FlushAllDatabasesAsync();
+        }
+    }
+
+    public async Task ExecuteSqlAsync(string sql, CancellationToken ct = default)
+    {
+        await using var connection = new NpgsqlConnection(_postgres.GetConnectionString());
+        await connection.OpenAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    public async Task<T?> ExecuteScalarAsync<T>(string sql, CancellationToken ct = default)
+    {
+        await using var connection = new NpgsqlConnection(_postgres.GetConnectionString());
+        await connection.OpenAsync(ct);
+        await using var command = new NpgsqlCommand(sql, connection);
+        var value = await command.ExecuteScalarAsync(ct);
+        if (value is null || value is DBNull)
+        {
+            return default;
+        }
+
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+
+    public async Task ExecuteMigrationScriptAsync(string fileName, CancellationToken ct = default)
+    {
+        var migrationPath = Path.Combine(_repositoryRoot, "src", "OsoujiSystem.Infrastructure", "Migrations", fileName);
+        var sql = await File.ReadAllTextAsync(migrationPath, ct);
+        await ExecuteSqlAsync(sql, ct);
+    }
+
+    public async Task FlushRedisAsync()
+    {
+        ArgumentNullException.ThrowIfNull(_redisConnection);
+
         foreach (var endpoint in _redisConnection.GetEndPoints())
         {
             var server = _redisConnection.GetServer(endpoint);

--- a/osouji-touban-service/tests/OsoujiSystem.WebApi.Tests/CleaningAreaApiTests.cs
+++ b/osouji-touban-service/tests/OsoujiSystem.WebApi.Tests/CleaningAreaApiTests.cs
@@ -362,6 +362,468 @@ public sealed class CleaningAreaApiTests(ApiIntegrationTestFixture fixture) : IA
         refreshed["data"]!["members"]![0]!["displayName"].Should().BeNull();
     }
 
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_ShouldImproveMembersDisplayNameAfterExecution()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+        var sourceUserId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000001")).StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES (
+                '{memberUserId}'::uuid,
+                '000001',
+                '',
+                'Active',
+                'OPS',
+                '{Guid.NewGuid()}'::uuid,
+                1,
+                'member@example.com',
+                now()
+            )
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                display_name = EXCLUDED.display_name,
+                updated_at = now();
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES (
+                '{sourceUserId}'::uuid,
+                '000001',
+                '  田中 花子  ',
+                'Active',
+                'OPS',
+                '{sourceEventId}'::uuid,
+                10,
+                'hanako@example.com',
+                now()
+            )
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                employee_number = EXCLUDED.employee_number,
+                display_name = EXCLUDED.display_name,
+                lifecycle_status = EXCLUDED.lifecycle_status,
+                department_code = EXCLUDED.department_code,
+                source_event_id = EXCLUDED.source_event_id,
+                aggregate_version = EXCLUDED.aggregate_version,
+                email_address = EXCLUDED.email_address,
+                updated_at = now();
+            """,
+            TestContext.Current.CancellationToken);
+
+        var before = await ApiTestHelper.GetAreaAsync(fixture, _client, areaId);
+        before["data"]!["members"]![0]!["displayName"].Should().BeNull();
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var after = await ApiTestHelper.GetAreaAsync(fixture, _client, areaId);
+        after["data"]!["members"]![0]!["displayName"]!.GetValue<string>().Should().Be("田中 花子");
+
+        var persistedDisplayName = await fixture.ExecuteScalarAsync<string>(
+            $"SELECT display_name FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        persistedDisplayName.Should().Be("田中 花子");
+    }
+
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_WhenReExecuted_ShouldRemainIdempotent()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+        var sourceUserId = Guid.NewGuid();
+        var sourceEventId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000001")).StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES (
+                '{memberUserId}'::uuid,
+                '000001',
+                '',
+                'Active',
+                'OPS',
+                '{Guid.NewGuid()}'::uuid,
+                1,
+                'member2@example.com',
+                now()
+            )
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                display_name = EXCLUDED.display_name,
+                updated_at = now();
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES (
+                '{sourceUserId}'::uuid,
+                '000001',
+                '鈴木 一郎',
+                'Active',
+                'OPS',
+                '{sourceEventId}'::uuid,
+                11,
+                'ichiro@example.com',
+                now()
+            )
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                employee_number = EXCLUDED.employee_number,
+                display_name = EXCLUDED.display_name,
+                lifecycle_status = EXCLUDED.lifecycle_status,
+                department_code = EXCLUDED.department_code,
+                source_event_id = EXCLUDED.source_event_id,
+                aggregate_version = EXCLUDED.aggregate_version,
+                email_address = EXCLUDED.email_address,
+                updated_at = now();
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var updatedAtAfterFirstRun = await fixture.ExecuteScalarAsync<DateTime>(
+            $"SELECT updated_at FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        var rowCountAfterFirstRun = await fixture.ExecuteScalarAsync<long>(
+            $"SELECT COUNT(*) FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var updatedAtAfterSecondRun = await fixture.ExecuteScalarAsync<DateTime>(
+            $"SELECT updated_at FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        var rowCountAfterSecondRun = await fixture.ExecuteScalarAsync<long>(
+            $"SELECT COUNT(*) FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+
+        rowCountAfterFirstRun.Should().Be(1);
+        rowCountAfterSecondRun.Should().Be(1);
+        updatedAtAfterSecondRun.Should().Be(updatedAtAfterFirstRun);
+    }
+
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_WithAmbiguousEmployeeNumber_ShouldLeaveDisplayNameNull()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000003")).StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES
+                ('{Guid.NewGuid()}'::uuid, '000003', '候補A', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 12, 'a@example.com', now()),
+                ('{Guid.NewGuid()}'::uuid, '000003', '候補B', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 13, 'b@example.com', now());
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var after = await ApiTestHelper.GetAreaAsync(fixture, _client, areaId);
+        after["data"]!["members"]![0]!["displayName"].Should().BeNull();
+
+        var memberDirectoryRows = await fixture.ExecuteScalarAsync<long>(
+            $"SELECT COUNT(*) FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        memberDirectoryRows.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_WhenMemberDirectoryRowMissing_ShouldInsertByEmployeeNumberUniqueMatch()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+        var sourceUserId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000021")).StatusCode.Should().Be(HttpStatusCode.Created);
+        await fixture.DrainProjectionAsync(TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteSqlAsync(
+            $"DELETE FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES (
+                '{sourceUserId}'::uuid,
+                '000021',
+                '中村 花',
+                'Active',
+                'OPS',
+                '{Guid.NewGuid()}'::uuid,
+                1,
+                'source-21@example.com',
+                now()
+            );
+            """,
+            TestContext.Current.CancellationToken);
+
+        var beforeRows = await fixture.ExecuteScalarAsync<long>(
+            $"SELECT COUNT(*) FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        beforeRows.Should().Be(0);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var persistedDisplayName = await fixture.ExecuteScalarAsync<string>(
+            $"SELECT display_name FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        persistedDisplayName.Should().Be("中村 花");
+
+        var area = await ApiTestHelper.GetAreaAsync(fixture, _client, areaId);
+        area["data"]!["members"]![0]!["displayName"]!.GetValue<string>().Should().Be("中村 花");
+    }
+
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_WhenEmployeeNumberAlsoMatches_ShouldPreferUserId()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000022")).StatusCode.Should().Be(HttpStatusCode.Created);
+        await fixture.DrainProjectionAsync(TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES
+                ('{memberUserId}'::uuid, '000022', '本人 表示名', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 1, 'self@example.com', now()),
+                ('{Guid.NewGuid()}'::uuid, '000022', '他人 表示名', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 2, 'other@example.com', now())
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                employee_number = EXCLUDED.employee_number,
+                display_name = EXCLUDED.display_name,
+                lifecycle_status = EXCLUDED.lifecycle_status,
+                department_code = EXCLUDED.department_code,
+                source_event_id = EXCLUDED.source_event_id,
+                aggregate_version = EXCLUDED.aggregate_version,
+                email_address = EXCLUDED.email_address,
+                updated_at = now();
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var persistedDisplayName = await fixture.ExecuteScalarAsync<string>(
+            $"SELECT display_name FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        persistedDisplayName.Should().Be("本人 表示名");
+
+        var area = await ApiTestHelper.GetAreaAsync(fixture, _client, areaId);
+        area["data"]!["members"]![0]!["displayName"]!.GetValue<string>().Should().Be("本人 表示名");
+    }
+
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_ShouldRecordExecutionMetrics()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000023")).StatusCode.Should().Be(HttpStatusCode.Created);
+        await fixture.DrainProjectionAsync(TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES
+                ('{Guid.NewGuid()}'::uuid, '000023', '補完 候補', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 1, 'source-23@example.com', now());
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+
+        var targetMemberCount = await fixture.ExecuteScalarAsync<long>(
+            "SELECT target_member_count FROM migration_area_member_display_name_backfill_runs ORDER BY run_id DESC LIMIT 1;",
+            TestContext.Current.CancellationToken);
+        var updatedMemberCount = await fixture.ExecuteScalarAsync<long>(
+            "SELECT updated_member_count FROM migration_area_member_display_name_backfill_runs ORDER BY run_id DESC LIMIT 1;",
+            TestContext.Current.CancellationToken);
+        var unresolvedMemberCount = await fixture.ExecuteScalarAsync<long>(
+            "SELECT unresolved_member_count FROM migration_area_member_display_name_backfill_runs ORDER BY run_id DESC LIMIT 1;",
+            TestContext.Current.CancellationToken);
+        var ambiguousMatchCount = await fixture.ExecuteScalarAsync<long>(
+            "SELECT ambiguous_match_count FROM migration_area_member_display_name_backfill_runs ORDER BY run_id DESC LIMIT 1;",
+            TestContext.Current.CancellationToken);
+        var missingRateBefore = await fixture.ExecuteScalarAsync<decimal>(
+            "SELECT missing_rate_before FROM migration_area_member_display_name_backfill_runs ORDER BY run_id DESC LIMIT 1;",
+            TestContext.Current.CancellationToken);
+        var missingRateAfter = await fixture.ExecuteScalarAsync<decimal>(
+            "SELECT missing_rate_after FROM migration_area_member_display_name_backfill_runs ORDER BY run_id DESC LIMIT 1;",
+            TestContext.Current.CancellationToken);
+
+        targetMemberCount.Should().Be(1);
+        updatedMemberCount.Should().Be(1);
+        unresolvedMemberCount.Should().Be(0);
+        ambiguousMatchCount.Should().Be(0);
+        missingRateBefore.Should().Be(1m);
+        missingRateAfter.Should().Be(0m);
+    }
+
+    [Fact]
+    public async Task BackfillMemberDisplayNameMigration_WithExistingDisplayName_ShouldKeepCurrentValue()
+    {
+        var areaId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+
+        await ApiTestHelper.RegisterAreaAsync(_client, areaId, "Main Area", (Guid.NewGuid(), "Sink", 10));
+        var etag = await ApiTestHelper.GetAreaEtagAsync(fixture, _client, areaId);
+        (await ApiTestHelper.AssignUserAsync(_client, areaId, memberUserId, etag, "000004")).StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await fixture.ExecuteSqlAsync(
+            $"""
+            INSERT INTO projection_user_directory (
+                user_id,
+                employee_number,
+                display_name,
+                lifecycle_status,
+                department_code,
+                source_event_id,
+                aggregate_version,
+                email_address,
+                updated_at
+            )
+            VALUES
+                ('{memberUserId}'::uuid, '000004', '既存 名称', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 10, 'existing@example.com', now()),
+                ('{Guid.NewGuid()}'::uuid, '000004', '候補 名称', 'Active', 'OPS', '{Guid.NewGuid()}'::uuid, 11, 'candidate@example.com', now())
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                employee_number = EXCLUDED.employee_number,
+                display_name = EXCLUDED.display_name,
+                lifecycle_status = EXCLUDED.lifecycle_status,
+                department_code = EXCLUDED.department_code,
+                source_event_id = EXCLUDED.source_event_id,
+                aggregate_version = EXCLUDED.aggregate_version,
+                email_address = EXCLUDED.email_address,
+                updated_at = now();
+            """,
+            TestContext.Current.CancellationToken);
+
+        await fixture.ExecuteMigrationScriptAsync("0010_backfill_area_member_display_name.sql", TestContext.Current.CancellationToken);
+        await fixture.FlushRedisAsync();
+
+        var persistedDisplayName = await fixture.ExecuteScalarAsync<string>(
+            $"SELECT display_name FROM projection_user_directory WHERE user_id = '{memberUserId}'::uuid;",
+            TestContext.Current.CancellationToken);
+        persistedDisplayName.Should().Be("既存 名称");
+
+        var area = await ApiTestHelper.GetAreaAsync(fixture, _client, areaId);
+        area["data"]!["members"]![0]!["displayName"]!.GetValue<string>().Should().Be("既存 名称");
+    }
+
     private async Task SeedUserDirectoryAsync(
         UserId userId,
         string employeeNumber,


### PR DESCRIPTION
## Background and Purpose
Issue #40 improved read-model JOIN behavior, but existing assigned members still had missing display names and continued to fall back to employee number in UI.

This PR adds a safe backfill migration for existing data with idempotency and observability.

## Implementation
- Added migration: src/OsoujiSystem.Infrastructure/Migrations/0010_backfill_area_member_display_name.sql
- Resolution priority:
  - First: exact user_id match
  - Second: unique employee_number match
- Ambiguous match skip:
  - If employee_number maps to multiple candidates, skip update to avoid false positives
- Idempotency:
  - UPSERT with update guard so existing valid display_name is not overwritten
- Observability:
  - Added migration_area_member_display_name_backfill_runs metrics table
  - Records target/updated/unresolved/ambiguous and before/after missing rates
  - Emits NOTICE summary per run
- Added tests:
  - tests/OsoujiSystem.WebApi.Tests/CleaningAreaApiTests.cs
  - tests/OsoujiSystem.WebApi.Tests/ApiIntegrationTestFixture.cs
- Updated docs:
  - docs/api-endpoint-design-v1.md
  - docs/issue-42-reflection.md

## Test Results
Executed from repository root:
- dotnet restore: success
- dotnet build: success
- dotnet test: success
- Total: 216/216 passed

## Risks and Operational Notes
- No PR blockers from review
- Medium operational risk:
  - Standard CREATE INDEX can introduce write lock impact depending on timing
- Recommended operation:
  - Apply during low-traffic window
  - Check migration_area_member_display_name_backfill_runs after execution
  - Invalidate Redis cache when immediate API reflection is required

## Issue
Closes #42
https://github.com/kokutaro/learn-k8s-app/issues/42
