### PR TITLE
fix: 409エラー文言を競合種別で出し分け、null detailsでも正しく表示

### DIFF
--- a/osouji-touban-service/osouji-system-frontend/src/lib/api.test.ts
+++ b/osouji-touban-service/osouji-system-frontend/src/lib/api.test.ts
@@ -647,11 +647,32 @@ describe('api client', () => {
       code: 'UnknownError',
       message: 'Server Error',
     })
+
+    server.use(
+      http.post('/api/v1/cleaning-areas/:areaId/members', () => HttpResponse.json({
+        error: {
+          code: 'DuplicateAreaMemberError',
+          message: '同じユーザーは同一エリアに重複所属できません。',
+          details: null,
+          args: { areaId, userId },
+        },
+      }, { status: 409 })),
+    )
+
+    await expect(assignUserToArea(areaId, '"area-v1"', userId)).rejects.toBeInstanceOf(ApiError)
+    await expect(assignUserToArea(areaId, '"area-v1"', userId)).rejects.toMatchObject({
+      status: 409,
+      code: 'DuplicateAreaMemberError',
+      message: '同じユーザーは同一エリアに重複所属できません。',
+    })
   })
 
   it('provides helper resolutions for labels, tones, and spot names', () => {
     expect(explainApiError(new ApiError(409, 'RepositoryConcurrency', 'Version mismatch'))).toBe(
       '最新状態に更新されました。内容を確認して再度操作してください。',
+    )
+    expect(explainApiError(new ApiError(409, 'RepositoryDuplicate', 'A duplicate aggregate was detected.'))).toBe(
+      '重複するデータが検出されました。内容を確認して再度操作してください。',
     )
     expect(explainApiError(new ApiError(409, 'DuplicateAreaMemberError', 'Conflict'))).toBe(
       'このユーザーはすでに担当エリアに割り当てられています。',
@@ -661,6 +682,42 @@ describe('api client', () => {
     )
     expect(explainApiError(new ApiError(409, 'DuplicateCleaningSpotError', 'Conflict'))).toBe(
       '同じ名前の掃除スポットがすでに存在します。別の名前で登録してください。',
+    )
+    expect(explainApiError(new ApiError(409, 'WeeklyPlanAlreadyExists', 'A weekly duty plan already exists.'))).toBe(
+      'この週の清掃計画はすでに作成されています。',
+    )
+    expect(explainApiError(new ApiError(409, 'DuplicateEmployeeNumberError', 'Conflict'))).toBe(
+      '同じ社員番号のユーザーはすでに登録されています。',
+    )
+    expect(explainApiError(new ApiError(409, 'DuplicateFacilityCodeError', 'Conflict'))).toBe(
+      '同じ施設コードの施設はすでに登録されています。',
+    )
+    expect(explainApiError(new ApiError(409, 'DuplicateAuthIdentityLinkError', 'Conflict'))).toBe(
+      'この認証アカウントはすでに別のユーザーに紐付けられています。',
+    )
+    expect(explainApiError(new ApiError(409, 'ManagedUserAlreadyArchivedError', 'Conflict'))).toBe(
+      'アーカイブ済みのユーザーは更新できません。',
+    )
+    expect(explainApiError(new ApiError(409, 'ManagedUserNotActiveError', 'Conflict'))).toBe(
+      'このユーザーは現在利用できません。',
+    )
+    expect(explainApiError(new ApiError(409, 'FacilityNotActiveError', 'Conflict'))).toBe(
+      'この施設は現在利用できません。',
+    )
+    expect(explainApiError(new ApiError(409, 'WeekAlreadyClosedError', 'Conflict'))).toBe(
+      'クローズ済みの週次計画は操作できません。',
+    )
+    expect(explainApiError(new ApiError(409, 'CleaningAreaHasNoSpotError', 'Conflict'))).toBe(
+      '清掃箇所が登録されていないため計画を作成できません。',
+    )
+    expect(explainApiError(new ApiError(409, 'NoAvailableUserForSpotError', 'Conflict'))).toBe(
+      '割り当て可能なユーザーがいません。担当メンバーを確認してください。',
+    )
+    expect(explainApiError(new ApiError(409, 'InvalidRebalanceRequestError', 'Conflict'))).toBe(
+      '再配分の内容が不正です。条件を確認してください。',
+    )
+    expect(explainApiError(new ApiError(409, 'InvalidTransferRequest', 'Conflict'))).toBe(
+      '転送リクエストの内容が不正です。',
     )
     expect(explainApiError(new ApiError(409, 'UnknownConflict', 'Conflict fallback message', [
       { field: 'name', message: '詳細メッセージ', code: 'Conflict' },

--- a/osouji-touban-service/osouji-system-frontend/src/lib/api.ts
+++ b/osouji-touban-service/osouji-system-frontend/src/lib/api.ts
@@ -28,9 +28,9 @@ import {
 export class ApiError extends Error {
   status: number
   code: string
-  details: Array<{ field: string; message: string; code: string }>
+  details: Array<{ field?: string | null; message: string; code?: string | null }>
 
-  constructor(status: number, code: string, message: string, details: Array<{ field: string; message: string; code: string }> = []) {
+  constructor(status: number, code: string, message: string, details: Array<{ field?: string | null; message: string; code?: string | null }> = []) {
     super(message)
     this.status = status
     this.code = code
@@ -60,9 +60,22 @@ const apiBase = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
 
 const conflictMessageByCode: Record<string, string> = {
   RepositoryConcurrency: '最新状態に更新されました。内容を確認して再度操作してください。',
+  RepositoryDuplicate: '重複するデータが検出されました。内容を確認して再度操作してください。',
   DuplicateAreaMemberError: 'このユーザーはすでに担当エリアに割り当てられています。',
   UserAlreadyAssignedToAnotherAreaError: 'このユーザーは別の担当エリアに割り当て済みです。割り当てを解除してから再度操作してください。',
   DuplicateCleaningSpotError: '同じ名前の掃除スポットがすでに存在します。別の名前で登録してください。',
+  WeeklyPlanAlreadyExists: 'この週の清掃計画はすでに作成されています。',
+  DuplicateEmployeeNumberError: '同じ社員番号のユーザーはすでに登録されています。',
+  DuplicateFacilityCodeError: '同じ施設コードの施設はすでに登録されています。',
+  DuplicateAuthIdentityLinkError: 'この認証アカウントはすでに別のユーザーに紐付けられています。',
+  ManagedUserAlreadyArchivedError: 'アーカイブ済みのユーザーは更新できません。',
+  ManagedUserNotActiveError: 'このユーザーは現在利用できません。',
+  FacilityNotActiveError: 'この施設は現在利用できません。',
+  WeekAlreadyClosedError: 'クローズ済みの週次計画は操作できません。',
+  CleaningAreaHasNoSpotError: '清掃箇所が登録されていないため計画を作成できません。',
+  NoAvailableUserForSpotError: '割り当て可能なユーザーがいません。担当メンバーを確認してください。',
+  InvalidRebalanceRequestError: '再配分の内容が不正です。条件を確認してください。',
+  InvalidTransferRequest: '転送リクエストの内容が不正です。',
 }
 
 function toQueryString(params: Record<string, string | number | undefined>) {

--- a/osouji-touban-service/osouji-system-frontend/src/lib/contracts.ts
+++ b/osouji-touban-service/osouji-system-frontend/src/lib/contracts.ts
@@ -6,17 +6,17 @@ export const guidSchema = z.string().regex(
 )
 
 export const apiErrorDetailSchema = z.object({
-  field: z.string(),
+  field: z.string().nullish(),
   message: z.string(),
-  code: z.string(),
+  code: z.string().nullish(),
 })
 
 export const apiErrorSchema = z.object({
   error: z.object({
     code: z.string(),
     message: z.string(),
-    details: z.array(apiErrorDetailSchema).optional(),
-    args: z.record(z.string(), z.unknown()).optional(),
+    details: z.array(apiErrorDetailSchema).nullish(),
+    args: z.record(z.string(), z.unknown()).nullish(),
   }),
 })
 


### PR DESCRIPTION
## 背景
APIがdetails: nullを返す409レスポンスに対し、frontend側のスキーマがnull非許容だったためパースに失敗し、ユーザー向け表示が通信エラー文言へフォールバックしていました。

## 変更内容
- frontendのAPIエラースキーマをnull許容に修正
  - apiErrorDetailSchemaのfield/codeをnullish対応
  - apiErrorSchemaのdetails/argsをnullish対応
- explainApiErrorの409メッセージ出し分けを拡充
  - RepositoryConcurrencyは再読み込み案内
  - そのほかの主要な409コードに個別メッセージを追加
  - ApiError.details型をnullishに合わせて更新
- テスト追加
  - 409のdetails: nullケースでもApiErrorとして扱えることを検証
  - 追加した409コードの文言出し分けを検証

## 影響範囲
- frontend error handling

## テスト
- npx vitest run src/lib/api.test.ts
  - 1 file, 10 tests passed

Closes #50