### PR TITLE
fix: 自動Release後にもProduction Deployを起動する

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -4,22 +4,69 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_run:
+    workflows:
+      - "Release On PR Merge"
+    types:
+      - completed
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  validate-tag:
+  resolve-tag:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.resolve.outputs.tag_name }}
+    steps:
+      - name: Resolve tag name
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_TAG: ${{ github.ref_name }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            tag_name="$PUSH_TAG"
+          else
+            if [[ -z "$WORKFLOW_HEAD_SHA" || "$WORKFLOW_HEAD_SHA" == "null" ]]; then
+              echo "workflow_run.head_sha is missing"
+              exit 1
+            fi
+
+            tag_name=$(gh api --paginate "repos/$REPO/releases?per_page=100" --jq '.[] | select((.target_commitish // "") == env.WORKFLOW_HEAD_SHA) | .tag_name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
+
+            if [[ -z "$tag_name" ]]; then
+              echo "No matching stable release tag found for head sha: $WORKFLOW_HEAD_SHA"
+              exit 1
+            fi
+          fi
+
+          echo "tag_name=$tag_name" >> "$GITHUB_OUTPUT"
+
+  validate-tag:
+    needs: [resolve-tag]
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.pass.outputs.tag_name }}
     steps:
       - name: Validate release tag format
         run: |
-          if [[ ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid release tag: ${{ github.ref_name }}"
+          if [[ ! "${{ needs.resolve-tag.outputs.tag_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: ${{ needs.resolve-tag.outputs.tag_name }}"
             echo "Expected format: vX.Y.Z"
             exit 1
           fi
+      - name: Pass tag output
+        id: pass
+        run: |
+          echo "tag_name=${{ needs.resolve-tag.outputs.tag_name }}" >> "$GITHUB_OUTPUT"
   retag-frontend:
     needs: [validate-tag]
     runs-on: ubuntu-latest
@@ -38,14 +85,14 @@ jobs:
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/osouji-system-frontend
           SRC_TAG=latest
-          DST_TAG=${{ github.ref_name }}
+          DST_TAG=${{ needs.validate-tag.outputs.tag_name }}
           docker pull "${IMAGE}:${SRC_TAG}"
           docker tag "${IMAGE}:${SRC_TAG}" "${IMAGE}:${DST_TAG}"
           docker push "${IMAGE}:${DST_TAG}"
       - name: Inspect retagged frontend image
         run: |
           docker buildx imagetools inspect \
-            ghcr.io/${{ github.repository_owner }}/osouji-system-frontend:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/osouji-system-frontend:${{ needs.validate-tag.outputs.tag_name }}
   retag-backend:
     needs: [validate-tag]
     runs-on: ubuntu-latest
@@ -64,17 +111,17 @@ jobs:
         run: |
           IMAGE=ghcr.io/${{ github.repository_owner }}/osouji-system-backend
           SRC_TAG=latest
-          DST_TAG=${{ github.ref_name }}
+          DST_TAG=${{ needs.validate-tag.outputs.tag_name }}
           docker pull "${IMAGE}:${SRC_TAG}"
           docker tag "${IMAGE}:${SRC_TAG}" "${IMAGE}:${DST_TAG}"
           docker push "${IMAGE}:${DST_TAG}"
       - name: Inspect retagged backend image
         run: |
           docker buildx imagetools inspect \
-            ghcr.io/${{ github.repository_owner }}/osouji-system-backend:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/osouji-system-backend:${{ needs.validate-tag.outputs.tag_name }}
   update-infra-repo:
     runs-on: ubuntu-latest
-    needs: [retag-frontend, retag-backend]
+    needs: [validate-tag, retag-frontend, retag-backend]
     steps:
       - uses: actions/checkout@v4
       - name: Update Image Tag in Infra Repository
@@ -82,7 +129,7 @@ jobs:
           git clone https://${{ secrets.INFRA_REPO_TOKEN }}@github.com/${{ github.repository_owner }}/${{ vars.INFRA_REPO_NAME }}.git
           cd ${{ vars.INFRA_REPO_NAME }}
 
-          NEW_TAGS=${{ github.ref_name }}
+          NEW_TAGS=${{ needs.validate-tag.outputs.tag_name }}
           sed -i "s/tag: .*/tag: ${NEW_TAGS}/g" argocd/apps/production/values-prod.yaml
 
           git config --global user.name "github-actions[bot]"
@@ -92,7 +139,7 @@ jobs:
           git push origin main
   send-deploy-marker:
     runs-on: ubuntu-latest
-    needs: update-infra-repo
+    needs: [validate-tag, update-infra-repo]
     steps:
       - name: Login to Tailscale
         uses: tailscale/github-action@v4
@@ -109,7 +156,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GRAFANA_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d '{
-              "text": "🚀 Production Deploy: ${{ github.ref_name }}",
+              "text": "🚀 Production Deploy: ${{ needs.validate-tag.outputs.tag_name }}",
               "tags": ["deploy", "production", "app-repo"],
               "time": '$NOW',
               "timeEnd": '$NOW'


### PR DESCRIPTION
## 概要
- production-deploy を push tag だけでなく Release On PR Merge の workflow_run 完了でも起動
- イベント別に対象タグを解決する resolve-tag ジョブを追加
- 後続ジョブは解決済みタグを参照するよう修正

## 目的
自動リリース（gh release create）で作成されたタグでは Production Deploy が発火しないケースを解消する。