### PR TITLE
fix: workflow_run経路は最新安定タグを採用

### DIFF
--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -28,40 +28,18 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           PUSH_TAG: ${{ github.ref_name }}
-          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-
-          WORKFLOW_PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number // ""' "$GITHUB_EVENT_PATH")
 
           if [[ "$EVENT_NAME" == "push" ]]; then
             tag_name="$PUSH_TAG"
           else
-            if [[ -z "$WORKFLOW_HEAD_SHA" || "$WORKFLOW_HEAD_SHA" == "null" ]]; then
-              echo "workflow_run.head_sha is missing"
-              exit 1
-            fi
-
-            merge_sha=""
-            if [[ -n "${WORKFLOW_PR_NUMBER:-}" && "${WORKFLOW_PR_NUMBER}" != "null" ]]; then
-              merge_sha=$(gh api "repos/$REPO/pulls/$WORKFLOW_PR_NUMBER" --jq '.merge_commit_sha // ""')
-            fi
-
-            candidate_sha="$WORKFLOW_HEAD_SHA"
-            if [[ -n "$merge_sha" ]]; then
-              candidate_sha="$merge_sha"
-            fi
-
             releases_json=$(gh api --paginate "repos/$REPO/releases?per_page=100" | jq -s 'add')
 
-            tag_name=$(printf '%s' "$releases_json" | jq -r --arg candidate_sha "$candidate_sha" '.[] | select((.target_commitish // "") == $candidate_sha) | .tag_name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-
-            if [[ -z "$tag_name" && -n "${WORKFLOW_PR_NUMBER:-}" && "${WORKFLOW_PR_NUMBER}" != "null" ]]; then
-              tag_name=$(printf '%s' "$releases_json" | jq -r --arg pr "$WORKFLOW_PR_NUMBER" '.[] | select(((.body // "") | contains("<!-- source-pr: " + $pr + " -->"))) | .tag_name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
-            fi
+            tag_name=$(printf '%s' "$releases_json" | jq -r '.[] | .tag_name' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)
 
             if [[ -z "$tag_name" ]]; then
-              echo "No matching stable release tag found for workflow run. head_sha=$WORKFLOW_HEAD_SHA pr=${WORKFLOW_PR_NUMBER:-<none>} merge_sha=${merge_sha:-<none>}"
+              echo "No stable release tag found for workflow_run trigger"
               exit 1
             fi
           fi


### PR DESCRIPTION
## 概要
- workflow_run イベントでは PR 情報が空になるため SHA/PR 解決を廃止
- Release On PR Merge 完了時は最新安定リリースタグ（vX.Y.Z）を採用する方式へ変更

## 目的
Production Deploy の resolve-tag 失敗を解消し、自動リリース後の連鎖デプロイを安定化する。