### PR TITLE
PR previewをArgoCD Webhook直接通知へ移行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -391,11 +391,10 @@ jobs:
           fi
 
           response_body="$(cat "$response_body_file")"
-          echo "ArgoCD webhook call failed: HTTP $http_status (event=pull_request)"
-          echo "Response body:"
-          echo "$response_body"
-
           if [[ "$response_body" == *"event not defined to be parsed"* ]]; then
+            echo "ArgoCD webhook returned compatibility error on pull_request event: HTTP $http_status"
+            echo "Response body:"
+            echo "$response_body"
             echo "Retrying with a synthetic push event for compatibility..."
 
             pr_number=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
@@ -484,6 +483,10 @@ jobs:
             echo "Hint: Verify ARGOCD_PREVIEW_WEBHOOK_URL points to the ApplicationSet webhook endpoint (not only argocd-server /api/webhook) or upgrade ArgoCD/ApplicationSet."
             exit 1
           fi
+
+          echo "ArgoCD webhook call failed: HTTP $http_status (event=pull_request)"
+          echo "Response body:"
+          echo "$response_body"
 
           echo "Hint: Verify ARGOCD_PREVIEW_WEBHOOK_URL points to the correct ArgoCD webhook endpoint and webhook secret settings."
           exit 1


### PR DESCRIPTION
## 概要\n- PRプレビュー環境の作成トリガーを preview-ready ラベルのポーリング依存から撤廃\n- GitHub Actions から Tailscale 経由で ArgoCD Webhook へ直接通知\n- Secret化URLを利用して通知先を管理\n\n## 変更点\n- .github/workflows/deploy.yml\n  - remove-preview から preview-ready ラベル削除処理を削除\n  - add-preview-ready-label ジョブを廃止\n  - notify-argocd-preview ジョブを追加\n  - tailscale/github-action@v4 で接続後、pull_request payload を webhook に POST\n\n## テスト観点\n- PR opened/synchronize/reopened で notify-argocd-preview が実行される\n- ARGOCD_PREVIEW_WEBHOOK_URL へPOSTされる\n- ラベルポーリング無しでArgoCD側が再生成/更新される