### PR TITLE
chore: update GitHub Actions uses to latest major versions

### DIFF
--- a/.github/workflows/preview-environment-ready.yml
+++ b/.github/workflows/preview-environment-ready.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upsert preview link comment on pull request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           MARKER: "<!-- preview-environment-link -->"
         with:
@@ -84,7 +84,7 @@ jobs:
 
       - name: Add preview-live label (optional)
         if: ${{ github.event.client_payload.pr_number != null }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = context.payload.client_payload.pr_number;

--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -68,14 +68,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Retag frontend image from base SHA to head SHA
         run: |
@@ -94,14 +94,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Retag backend image from base SHA to head SHA
         run: |

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- update .github/workflows/preview-environment-ready.yml from actions/github-script@v7 to @v8
- update .github/workflows/production-deploy.yaml from docker/login-action@v3 and docker/setup-buildx-action@v3 to @v4
- update .github/workflows/release-on-pr-merge.yml from actions/checkout@v4 to @v6

## Validation
- verified latest release tags via GitHub API
- verified all workflow uses entries are now on latest major versions
